### PR TITLE
Enhancements & fixes

### DIFF
--- a/Template APP MSSQL 2008-2016.xml
+++ b/Template APP MSSQL 2008-2016.xml
@@ -2067,6 +2067,48 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
+                            <name>SQL Server, Instance {#INST}:General Statistics\Processes Blocked</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:General Statistics\Processes Blocked&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>3</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL STATS</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item_prototype/>
+                        </item_prototype>
+                        <item_prototype>
                             <name>SQL Server, Instance {#INST}:Locks(_Total)\Lock Timeouts/sec</name>
                             <type>0</type>
                             <snmp_community/>

--- a/Template APP MSSQL 2008-2016.xml
+++ b/Template APP MSSQL 2008-2016.xml
@@ -60,7 +60,7 @@
                     <description/>
                     <item_prototypes>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}: Access Methods\Page Splits/sec</name>
+                            <name>SQL Server Instance {#INST}: Access Methods\Page Splits/sec</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -102,7 +102,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}: Bytes Received from Replica/sec</name>
+                            <name>SQL Server Instance {#INST}: Bytes Received from Replica/sec</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -144,7 +144,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}: Bytes Sent to Replica/sec</name>
+                            <name>SQL Server Instance {#INST}: Bytes Sent to Replica/sec</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -186,7 +186,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}: Bytes Sent to Transport/sec</name>
+                            <name>SQL Server Instance {#INST}: Bytes Sent to Transport/sec</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -228,7 +228,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}: Flow Control/sec</name>
+                            <name>SQL Server Instance {#INST}: Flow Control/sec</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -270,7 +270,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}: Flow Control Time (ms/sec)</name>
+                            <name>SQL Server Instance {#INST}: Flow Control Time (ms/sec)</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -312,7 +312,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}: Receives from Replica/sec</name>
+                            <name>SQL Server Instance {#INST}: Receives from Replica/sec</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -354,7 +354,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}: Resent Messages/sec</name>
+                            <name>SQL Server Instance {#INST}: Resent Messages/sec</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -396,7 +396,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}: Sends to Replica/sec</name>
+                            <name>SQL Server Instance {#INST}: Sends to Replica/sec</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -438,7 +438,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}: Sends to Transport/sec</name>
+                            <name>SQL Server Instance {#INST}: Sends to Transport/sec</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -480,7 +480,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}: Buffer Manager\Page life expectancy</name>
+                            <name>SQL Server Instance {#INST}: Buffer Manager\Page life expectancy</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -522,7 +522,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}: Buffer Manager\Page reads/sec</name>
+                            <name>SQL Server Instance {#INST}: Buffer Manager\Page reads/sec</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -564,7 +564,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}: Buffer Manager\Page writes/sec</name>
+                            <name>SQL Server Instance {#INST}: Buffer Manager\Page writes/sec</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -606,7 +606,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}: Database Flow Control Delay</name>
+                            <name>SQL Server Instance {#INST}: Database Flow Control Delay</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -644,7 +644,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}: Database Flow Controls/sec</name>
+                            <name>SQL Server Instance {#INST}: Database Flow Controls/sec</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -686,7 +686,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}: File Bytes Received/sec</name>
+                            <name>SQL Server Instance {#INST}: File Bytes Received/sec</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -724,7 +724,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}: Group Commits/Sec</name>
+                            <name>SQL Server Instance {#INST}: Group Commits/Sec</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -762,7 +762,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}: Group Commit Time</name>
+                            <name>SQL Server Instance {#INST}: Group Commit Time</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -800,7 +800,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}: Log Bytes Compressed/sec</name>
+                            <name>SQL Server Instance {#INST}: Log Bytes Compressed/sec</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -838,7 +838,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}: Log Bytes Decompressed/sec</name>
+                            <name>SQL Server Instance {#INST}: Log Bytes Decompressed/sec</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -876,7 +876,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}: Log Bytes Received/sec</name>
+                            <name>SQL Server Instance {#INST}: Log Bytes Received/sec</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -914,7 +914,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}: Log Compression Cache hits/sec</name>
+                            <name>SQL Server Instance {#INST}: Log Compression Cache hits/sec</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -956,7 +956,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}: Log Compression Cache misses/sec</name>
+                            <name>SQL Server Instance {#INST}: Log Compression Cache misses/sec</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -994,7 +994,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}: Log Compressions/sec</name>
+                            <name>SQL Server Instance {#INST}: Log Compressions/sec</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -1032,7 +1032,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}: Log Decompressions/sec</name>
+                            <name>SQL Server Instance {#INST}: Log Decompressions/sec</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -1070,7 +1070,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}: Log remaining for undo</name>
+                            <name>SQL Server Instance {#INST}: Log remaining for undo</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -1108,7 +1108,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}: Log Send Queue</name>
+                            <name>SQL Server Instance {#INST}: Log Send Queue</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -1150,7 +1150,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}: Mirrored Write Transactions/sec</name>
+                            <name>SQL Server Instance {#INST}: Mirrored Write Transactions/sec</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -1188,7 +1188,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}: Recovery Queue</name>
+                            <name>SQL Server Instance {#INST}: Recovery Queue</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -1230,7 +1230,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}: Redo blocked/sec</name>
+                            <name>SQL Server Instance {#INST}: Redo blocked/sec</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -1268,7 +1268,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}: Redo Bytes Remaining</name>
+                            <name>SQL Server Instance {#INST}: Redo Bytes Remaining</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -1306,7 +1306,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}: Redone Bytes/sec</name>
+                            <name>SQL Server Instance {#INST}: Redone Bytes/sec</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -1344,7 +1344,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}: Redones/sec</name>
+                            <name>SQL Server Instance {#INST}: Redones/sec</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -1382,7 +1382,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}: Total Log requiring undo</name>
+                            <name>SQL Server Instance {#INST}: Total Log requiring undo</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -1420,7 +1420,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}: Transaction Delay</name>
+                            <name>SQL Server Instance {#INST}: Transaction Delay</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -1458,7 +1458,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}: Databases(_Total)\Percent Log Used</name>
+                            <name>SQL Server Instance {#INST}: Databases(_Total)\Percent Log Used</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -2025,7 +2025,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}:General Statistics\User Connections</name>
+                            <name>SQL Server Instance {#INST}:General Statistics\User Connections</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -2067,7 +2067,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}:General Statistics\Processes Blocked</name>
+                            <name>SQL Server Instance {#INST}:General Statistics\Processes Blocked</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -2109,7 +2109,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}:Locks(_Total)\Lock Timeouts/sec</name>
+                            <name>SQL Server Instance {#INST}:Locks(_Total)\Lock Timeouts/sec</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -2151,7 +2151,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}:Locks(_Total)\Number of Deadlocks/sec</name>
+                            <name>SQL Server Instance {#INST}:Locks(_Total)\Number of Deadlocks/sec</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -2193,7 +2193,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}:Memory Manager\Memory Grants Pending</name>
+                            <name>SQL Server Instance {#INST}:Memory Manager\Memory Grants Pending</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -2235,7 +2235,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}:Memory Manager\Target Server Memory (KB)</name>
+                            <name>SQL Server Instance {#INST}:Memory Manager\Target Server Memory (KB)</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -2277,7 +2277,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}:Memory Manager\Total Server Memory (KB)</name>
+                            <name>SQL Server Instance {#INST}:Memory Manager\Total Server Memory (KB)</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -2319,7 +2319,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}:SQL Statistics\Batch Requests/sec</name>
+                            <name>SQL Server Instance {#INST}:SQL Statistics\Batch Requests/sec</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -2361,7 +2361,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}:SQL Statistics\SQL Compilations/sec</name>
+                            <name>SQL Server Instance {#INST}:SQL Statistics\SQL Compilations/sec</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -2403,7 +2403,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}:SQL Statistics\SQL Re-Compilations/sec</name>
+                            <name>SQL Server Instance {#INST}:SQL Statistics\SQL Re-Compilations/sec</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -2445,7 +2445,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}:Memory grant queue waits/Average wait time (ms)</name>
+                            <name>SQL Server Instance {#INST}:Memory grant queue waits/Average wait time (ms)</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -2487,7 +2487,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}:Network IO waits/Average wait time (ms)</name>
+                            <name>SQL Server Instance {#INST}:Network IO waits/Average wait time (ms)</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -2529,7 +2529,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}:Page IO latch waits/Average wait time (ms)</name>
+                            <name>SQL Server Instance {#INST}:Page IO latch waits/Average wait time (ms)</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -2571,7 +2571,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}:Memory grant queue waits/Cumulative wait time (ms) per second</name>
+                            <name>SQL Server Instance {#INST}:Memory grant queue waits/Cumulative wait time (ms) per second</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -2613,7 +2613,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}:Network IO waits/Cumulative wait time (ms) per second</name>
+                            <name>SQL Server Instance {#INST}:Network IO waits/Cumulative wait time (ms) per second</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -2655,7 +2655,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}:Page IO latch waits/Cumulative wait time (ms) per second</name>
+                            <name>SQL Server Instance {#INST}:Page IO latch waits/Cumulative wait time (ms) per second</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -2697,7 +2697,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}:Memory grant queue waits/Waits in progress</name>
+                            <name>SQL Server Instance {#INST}:Memory grant queue waits/Waits in progress</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -2739,7 +2739,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}:Network IO waits/Waits in progress</name>
+                            <name>SQL Server Instance {#INST}:Network IO waits/Waits in progress</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -2781,7 +2781,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}:Page IO latch waits/Waits in progress</name>
+                            <name>SQL Server Instance {#INST}:Page IO latch waits/Waits in progress</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -2823,7 +2823,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}:Memory grant queue waits/Waits started per second</name>
+                            <name>SQL Server Instance {#INST}:Memory grant queue waits/Waits started per second</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -2865,7 +2865,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}:Network IO waits/Waits started per second</name>
+                            <name>SQL Server Instance {#INST}:Network IO waits/Waits started per second</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -2907,7 +2907,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}:Page IO latch waits/Waits started per second</name>
+                            <name>SQL Server Instance {#INST}:Page IO latch waits/Waits started per second</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -3074,7 +3074,7 @@ Setup a rule for &quot;event tag pair&quot;, use EC=EC, and set operation to clo
                     <description/>
                     <item_prototypes>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}: Error Log File (LOGCount)</name>
+                            <name>SQL Server Instance {#INST}: Error Log File (LOGCount)</name>
                             <type>7</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -3116,7 +3116,7 @@ Setup a rule for &quot;event tag pair&quot;, use EC=EC, and set operation to clo
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}: Error Log File (LOG)</name>
+                            <name>SQL Server Instance {#INST}: Error Log File (LOG)</name>
                             <type>7</type>
                             <snmp_community/>
                             <snmp_oid/>

--- a/Template APP MSSQL 2008-2016.xml
+++ b/Template APP MSSQL 2008-2016.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
     <version>4.0</version>
-    <date>2019-07-02T20:21:01Z</date>
+    <date>2019-07-05T17:22:53Z</date>
     <groups>
         <group>
             <name>MSSQL Servers</name>
@@ -4566,22 +4566,6 @@
                         </item_prototype>
                     </item_prototypes>
                     <trigger_prototypes>
-                        <trigger_prototype>
-                            <expression>{Template App MSSQL 2008-2016:log.count[{#ERRORLOG},Error|Failed,&quot;UTF-16&quot;].sum(5m)}&gt;0</expression>
-                            <recovery_mode>0</recovery_mode>
-                            <recovery_expression/>
-                            <name>Errors in {#IINST} ERRORLOG</name>
-                            <correlation_mode>0</correlation_mode>
-                            <correlation_tag/>
-                            <url/>
-                            <status>0</status>
-                            <priority>2</priority>
-                            <description/>
-                            <type>0</type>
-                            <manual_close>0</manual_close>
-                            <dependencies/>
-                            <tags/>
-                        </trigger_prototype>
                         <trigger_prototype>
                             <expression>{Template App MSSQL 2008-2016:log.count[{#ERRORLOG},Error|Failed,&quot;UTF-16&quot;].sum(5m)}&gt;0</expression>
                             <recovery_mode>0</recovery_mode>

--- a/Template APP MSSQL 2008-2016.xml
+++ b/Template APP MSSQL 2008-2016.xml
@@ -2953,7 +2953,7 @@
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
-                            <key>system.run[&quot;powershell C:\'Program Files'\'Zabbix Agent'\scripts\database_status_disc.ps1 -instName '{#INST}' -dbName '{#DBNAME}'&quot;]</key>
+                            <key>mssql.dbstatus</key>
                             <delay>1m</delay>
                             <history>90d</history>
                             <trends>0</trends>

--- a/Template APP MSSQL 2008-2016.xml
+++ b/Template APP MSSQL 2008-2016.xml
@@ -1500,7 +1500,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}, DB {#DBNAME}: Active Transactions</name>
+                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Active Transactions</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -1542,7 +1542,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}, DB {#DBNAME}: Data File Size</name>
+                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Data File Size</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -1589,7 +1589,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}, DB {#DBNAME}: Log Bytes Flushed/sec</name>
+                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Bytes Flushed/sec</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -1627,7 +1627,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}, DB {#DBNAME}: Log File Size</name>
+                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Log File Size</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -1674,7 +1674,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}, DB {#DBNAME}: Log File Used Size</name>
+                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Log File Used Size</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -1721,7 +1721,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}, DB {#DBNAME}: Log Flushes/sec</name>
+                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Flushes/sec</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -1759,7 +1759,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}, DB {#DBNAME}: Log Flush Waits/sec</name>
+                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Flush Waits/sec</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -1797,7 +1797,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}, DB {#DBNAME}: Log Flush Wait Time</name>
+                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Flush Wait Time</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -1835,7 +1835,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}, DB {#DBNAME}: Log Growths</name>
+                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Growths</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -1873,7 +1873,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}, DB {#DBNAME}: Log Shrinks</name>
+                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Shrinks</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -1911,7 +1911,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}, DB {#DBNAME}: Log Truncations</name>
+                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Truncations</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -1949,7 +1949,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}, DB {#DBNAME}: Percent Log Used</name>
+                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Percent Log Used</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -1987,7 +1987,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}, DB {#DBNAME}: Transactions per second</name>
+                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Transactions per second</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -2949,7 +2949,7 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
-                            <name>SQL Server, Instance {#INST}, DB {#DBNAME}: Database Status</name>
+                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Database Status</name>
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>

--- a/Template APP MSSQL 2008-2016.xml
+++ b/Template APP MSSQL 2008-2016.xml
@@ -1,9000 +1,9016 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
-  <version>4.0</version>
-  <date>2019-06-28T15:54:11Z</date>
-  <groups>
-    <group>
-      <name>MSSQL Servers</name>
-    </group>
-    <group>
-      <name>Templates</name>
-    </group>
-  </groups>
-  <templates>
-    <template>
-      <template>Template App MSSQL 2008-2016</template>
-      <name>Template App MSSQL 2008-2016</name>
-      <description />
-      <groups>
+    <version>4.0</version>
+    <date>2019-07-02T20:21:01Z</date>
+    <groups>
         <group>
-          <name>MSSQL Servers</name>
+            <name>MSSQL Servers</name>
         </group>
         <group>
-          <name>Templates</name>
+            <name>Templates</name>
         </group>
-      </groups>
-      <applications />
-      <items />
-      <discovery_rules>
-        <discovery_rule>
-          <name>Database Discovery - Default Instance</name>
-          <type>0</type>
-          <snmp_community />
-          <snmp_oid />
-          <key>mssql.default.db.discovery</key>
-          <delay>1h</delay>
-          <status>0</status>
-          <allowed_hosts />
-          <snmpv3_contextname />
-          <snmpv3_securityname />
-          <snmpv3_securitylevel>0</snmpv3_securitylevel>
-          <snmpv3_authprotocol>0</snmpv3_authprotocol>
-          <snmpv3_authpassphrase />
-          <snmpv3_privprotocol>0</snmpv3_privprotocol>
-          <snmpv3_privpassphrase />
-          <params />
-          <ipmi_sensor />
-          <authtype>0</authtype>
-          <username />
-          <password />
-          <publickey />
-          <privatekey />
-          <port />
-          <filter>
-            <evaltype>0</evaltype>
-            <formula />
-            <conditions />
-          </filter>
-          <lifetime>30d</lifetime>
-          <description />
-          <item_prototypes>
-            <item_prototype>
-              <name>SQL Server Instance {#INST} DB {#DBNAME}: Database Status</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>mssql.default.dbstatus[{#INST},{#DBNAME}]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>0</trends>
-              <status>0</status>
-              <value_type>4</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL DATABASE</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Access Methods\Page Splits/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Access Methods\Page Splits/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL ACCESS METHODS</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Bytes Received from Replica/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Availability Replica(_Total)\Bytes Received from Replica/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Bytes Sent to Replica/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Availability Replica(_Total)\Bytes Sent to Replica/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Bytes Sent to Transport/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Availability Replica(_Total)\Bytes Sent to Transport/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Flow Control/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Availability Replica(_Total)\Flow Control/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Flow Control Time (ms/sec)</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Availability Replica(_Total)\Flow Control Time (ms/sec)&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Receives from Replica/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Availability Replica(_Total)\Receives from Replica/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Resent Messages/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Availability Replica(_Total)\Resent Messages/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Sends to Replica/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Availability Replica(_Total)\Sends to Replica/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Sends to Transport/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Availability Replica(_Total)\Sends to Transport/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Buffer Manager\Page life expectancy</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Buffer Manager\Page life expectancy&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL MEMORY</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Buffer Manager\Page reads/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Buffer Manager\Page reads/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL MEMORY</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Buffer Manager\Page writes/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Buffer Manager\Page writes/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL MEMORY</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Database Flow Control Delay</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Database Flow Control Delay&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Database Flow Controls/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Database Flow Controls/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: File Bytes Received/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\File Bytes Received/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Group Commits/Sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Group Commits/Sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Group Commit Time</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Group Commit Time&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Log Bytes Compressed/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Log Bytes Compressed/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Log Bytes Decompressed/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Log Bytes Decompressed/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Log Bytes Received/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Log Bytes Received/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Log Compression Cache hits/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Log Compression Cache hits/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Log Compression Cache misses/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Log Compression Cache misses/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Log Compressions/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Log Compressions/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Log Decompressions/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Log Decompressions/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Log remaining for undo</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Log remaining for undo&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Log Send Queue</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Log Send Queue&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Mirrored Write Transactions/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Mirrored Write Transactions/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Recovery Queue</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Recovery Queue&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Redo blocked/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Redo blocked/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Redo Bytes Remaining</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Redo Bytes Remaining&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Redone Bytes/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Redone Bytes/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes />
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Redones/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Redones/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Total Log requiring undo</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Total Log requiring undo&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Transaction Delay</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Transaction Delay&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Databases(_Total)\Percent Log Used</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Databases(_Total)\Percent Log Used&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL DATABASE</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST} DB {#DBNAME}: Active Transactions</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Databases({#DBNAME})\Active Transactions&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description>Number of active transactions for the database.</description>
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL DATABASE</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST} DB {#DBNAME}: Data File Size</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Databases({#DBNAME})\Data File(s) Size (KB)&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units>B</units>
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description>Cumulative size (in kilobytes) of all the data files in the database including any automatic growth. Monitoring this counter is useful, for example, for determining the correct size of tempdb.</description>
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing>
-                <step>
-                  <type>1</type>
-                  <params>1024</params>
-                </step>
-              </preprocessing>
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL DATABASE</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Bytes Flushed/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Databases({#DBNAME})\Log Bytes Flushed/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units>B</units>
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description>Total number of log bytes flushed per second. Useful for determining trends and utilization of the transaction log.</description>
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL DATABASE</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST} DB {#DBNAME}: Log File Size</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Databases({#DBNAME})\Log File(s) Size (KB)&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units>B</units>
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description>Cumulative size (in kilobytes) of all the transaction log files in the database.</description>
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing>
-                <step>
-                  <type>1</type>
-                  <params>1024</params>
-                </step>
-              </preprocessing>
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL DATABASE</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST} DB {#DBNAME}: Log File Used Size</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Databases({#DBNAME})\Log File(s) Used Size (KB)&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units>B</units>
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description>The cumulative used size of all the log files in the database.</description>
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing>
-                <step>
-                  <type>1</type>
-                  <params>1024</params>
-                </step>
-              </preprocessing>
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL DATABASE</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Flushes/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Databases({#DBNAME})\Log Flushes/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description>Number of log flushes per second.</description>
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL DATABASE</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Flush Waits/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Databases({#DBNAME})\Log Flush Waits/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description>Number of commits per second waiting for the log flush.</description>
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL DATABASE</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Flush Wait Time</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Databases({#DBNAME})\Log Flush Wait Time&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units>ms</units>
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description>Total wait time (in milliseconds) to flush the log. On an AlwaysOn secondary database, this value indicates the wait time for log records to be hardened to disk.</description>
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL DATABASE</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Growths</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Databases({#DBNAME})\Log Growths&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description>Total number of times the transaction log for the database has been expanded.</description>
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL DATABASE</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Shrinks</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Databases({#DBNAME})\Log Shrinks&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description>Total number of times the transaction log for the database has been shrunk.</description>
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL DATABASE</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Truncations</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Databases({#DBNAME})\Log Truncations&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description>The number of times the transaction log has been shrunk.</description>
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL DATABASE</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST} DB {#DBNAME}: Percent Log Used</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Databases({#DBNAME})\Percent Log Used&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units>%</units>
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description>Percentage of space in the log that is in use.</description>
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL DATABASE</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST} DB {#DBNAME}: Transactions per second</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Databases({#DBNAME})\Transactions/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL DATABASE</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:General Statistics\Processes Blocked</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:General Statistics\Processes Blocked&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL STATS</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:General Statistics\User Connections</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:General Statistics\User Connections&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL STATS</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:Locks(_Total)\Lock Timeouts/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Locks(_Total)\Lock Timeouts/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL LOCKS</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:Locks(_Total)\Number of Deadlocks/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Locks(_Total)\Number of Deadlocks/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL LOCKS</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:Memory Manager\Memory Grants Pending</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Memory Manager\Memory Grants Pending&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL MEMORY</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:Memory Manager\Target Server Memory (KB)</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Memory Manager\Target Server Memory (KB)&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units>KB</units>
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL MEMORY</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:Memory Manager\Total Server Memory (KB)</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Memory Manager\Total Server Memory (KB)&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units>KB</units>
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL MEMORY</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:SQL Statistics\Batch Requests/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:SQL Statistics\Batch Requests/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL STATS</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:SQL Statistics\SQL Compilations/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:SQL Statistics\SQL Compilations/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL STATS</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:SQL Statistics\SQL Re-Compilations/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:SQL Statistics\SQL Re-Compilations/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL STATS</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:Memory grant queue waits/Average wait time (ms)</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Wait Statistics(Average wait time (ms))\Memory grant queue waits&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units>ms</units>
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL WAITS</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:Network IO waits/Average wait time (ms)</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Wait Statistics(Average wait time (ms))\Network IO waits&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units>ms</units>
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL WAITS</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:Page IO latch waits/Average wait time (ms)</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Wait Statistics(Average wait time (ms))\Page IO latch waits&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units>ms</units>
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL WAITS</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:Memory grant queue waits/Cumulative wait time (ms) per second</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Wait Statistics(Cumulative wait time (ms) per second)\Memory grant queue waits&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units>ms</units>
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL WAITS</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:Network IO waits/Cumulative wait time (ms) per second</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Wait Statistics(Cumulative wait time (ms) per second)\Network IO waits&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units>ms</units>
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL WAITS</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:Page IO latch waits/Cumulative wait time (ms) per second</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Wait Statistics(Cumulative wait time (ms) per second)\Page IO latch waits&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units>ms</units>
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL WAITS</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:Memory grant queue waits/Waits in progress</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Wait Statistics(Waits in progress)\Memory grant queue waits&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units>ms</units>
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL WAITS</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:Network IO waits/Waits in progress</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Wait Statistics(Waits in progress)\Network IO waits&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units>ms</units>
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL WAITS</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:Page IO latch waits/Waits in progress</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Wait Statistics(Waits in progress)\Page IO latch waits&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units>ms</units>
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL WAITS</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:Memory grant queue waits/Waits started per second</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Wait Statistics(Waits started per second)\Memory grant queue waits&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units>ms</units>
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL WAITS</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:Network IO waits/Waits started per second</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Wait Statistics(Waits started per second)\Network IO waits&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units>ms</units>
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL WAITS</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:Page IO latch waits/Waits started per second</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\SQLServer:Wait Statistics(Waits started per second)\Page IO latch waits&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units>ms</units>
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL WAITS</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-          </item_prototypes>
-          <trigger_prototypes />
-          <graph_prototypes />
-          <host_prototypes />
-          <jmx_endpoint />
-          <timeout>3s</timeout>
-          <url />
-          <query_fields />
-          <posts />
-          <status_codes>200</status_codes>
-          <follow_redirects>1</follow_redirects>
-          <post_type>0</post_type>
-          <http_proxy />
-          <headers />
-          <retrieve_mode>0</retrieve_mode>
-          <request_method>0</request_method>
-          <allow_traps>0</allow_traps>
-          <ssl_cert_file />
-          <ssl_key_file />
-          <ssl_key_password />
-          <verify_peer>0</verify_peer>
-          <verify_host>0</verify_host>
-        </discovery_rule>
-        <discovery_rule>
-          <name>SQL Error Log</name>
-          <type>0</type>
-          <snmp_community />
-          <snmp_oid />
-          <key>mssql.errorlog</key>
-          <delay>1h</delay>
-          <status>0</status>
-          <allowed_hosts />
-          <snmpv3_contextname />
-          <snmpv3_securityname />
-          <snmpv3_securitylevel>0</snmpv3_securitylevel>
-          <snmpv3_authprotocol>0</snmpv3_authprotocol>
-          <snmpv3_authpassphrase />
-          <snmpv3_privprotocol>0</snmpv3_privprotocol>
-          <snmpv3_privpassphrase />
-          <params />
-          <ipmi_sensor />
-          <authtype>0</authtype>
-          <username />
-          <password />
-          <publickey />
-          <privatekey />
-          <port />
-          <filter>
-            <evaltype>0</evaltype>
-            <formula />
-            <conditions />
-          </filter>
-          <lifetime>30d</lifetime>
-          <description />
-          <item_prototypes>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Error Log File (LOGCount)</name>
-              <type>7</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>log.count[{#ERRORLOG},Error|Failed,&quot;UTF-16&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>3</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL Error Log</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Error Log File (LOG)</name>
-              <type>7</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>log[{#ERRORLOG},Error|Failed,&quot;UTF-16&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>0</trends>
-              <status>0</status>
-              <value_type>2</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL Error Log</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-          </item_prototypes>
-          <trigger_prototypes>
-            <trigger_prototype>
-              <expression>{Template App MSSQL 2008-2016:log.count[{#ERRORLOG},Error|Failed,&quot;UTF-16&quot;].sum(5m)}&gt;0</expression>
-              <recovery_mode>0</recovery_mode>
-              <recovery_expression />
-              <name>Errors in {#IINST} ERRORLOG</name>
-              <correlation_mode>0</correlation_mode>
-              <correlation_tag />
-              <url />
-              <status>0</status>
-              <priority>2</priority>
-              <description />
-              <type>0</type>
-              <manual_close>0</manual_close>
-              <dependencies />
-              <tags />
-            </trigger_prototype>
-          </trigger_prototypes>
-          <graph_prototypes />
-          <host_prototypes />
-          <jmx_endpoint />
-          <timeout>3s</timeout>
-          <url />
-          <query_fields />
-          <posts />
-          <status_codes>200</status_codes>
-          <follow_redirects>1</follow_redirects>
-          <post_type>0</post_type>
-          <http_proxy />
-          <headers />
-          <retrieve_mode>0</retrieve_mode>
-          <request_method>0</request_method>
-          <allow_traps>0</allow_traps>
-          <ssl_cert_file />
-          <ssl_key_file />
-          <ssl_key_password />
-          <verify_peer>0</verify_peer>
-          <verify_host>0</verify_host>
-        </discovery_rule>
-        <discovery_rule>
-          <name>Database Discovery - Named Instances</name>
-          <type>0</type>
-          <snmp_community />
-          <snmp_oid />
-          <key>mssql.named.db.discovery</key>
-          <delay>1h</delay>
-          <status>0</status>
-          <allowed_hosts />
-          <snmpv3_contextname />
-          <snmpv3_securityname />
-          <snmpv3_securitylevel>0</snmpv3_securitylevel>
-          <snmpv3_authprotocol>0</snmpv3_authprotocol>
-          <snmpv3_authpassphrase />
-          <snmpv3_privprotocol>0</snmpv3_privprotocol>
-          <snmpv3_privpassphrase />
-          <params />
-          <ipmi_sensor />
-          <authtype>0</authtype>
-          <username />
-          <password />
-          <publickey />
-          <privatekey />
-          <port />
-          <filter>
-            <evaltype>0</evaltype>
-            <formula />
-            <conditions />
-          </filter>
-          <lifetime>30d</lifetime>
-          <description />
-          <item_prototypes>
-            <item_prototype>
-              <name>SQL Server Instance {#INST} DB {#DBNAME}: Database Status</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>mssql.named.dbstatus[{#INST},{#DBNAME}]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>0</trends>
-              <status>0</status>
-              <value_type>4</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL DATABASE</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Access Methods\Page Splits/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Access Methods\Page Splits/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL ACCESS METHODS</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Bytes Received from Replica/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Availability Replica(_Total)\Bytes Received from Replica/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Bytes Sent to Replica/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Availability Replica(_Total)\Bytes Sent to Replica/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Bytes Sent to Transport/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Availability Replica(_Total)\Bytes Sent to Transport/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Flow Control/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Availability Replica(_Total)\Flow Control/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Flow Control Time (ms/sec)</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Availability Replica(_Total)\Flow Control Time (ms/sec)&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Receives from Replica/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Availability Replica(_Total)\Receives from Replica/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Resent Messages/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Availability Replica(_Total)\Resent Messages/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Sends to Replica/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Availability Replica(_Total)\Sends to Replica/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Sends to Transport/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Availability Replica(_Total)\Sends to Transport/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Buffer Manager\Page life expectancy</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Buffer Manager\Page life expectancy&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL MEMORY</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Buffer Manager\Page reads/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Buffer Manager\Page reads/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL MEMORY</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Buffer Manager\Page writes/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Buffer Manager\Page writes/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL MEMORY</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Database Flow Control Delay</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Database Flow Control Delay&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Database Flow Controls/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Database Flow Controls/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: File Bytes Received/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\File Bytes Received/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Group Commits/Sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Group Commits/Sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Group Commit Time</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Group Commit Time&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Log Bytes Compressed/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Log Bytes Compressed/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Log Bytes Decompressed/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Log Bytes Decompressed/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Log Bytes Received/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Log Bytes Received/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Log Compression Cache hits/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Log Compression Cache hits/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Log Compression Cache misses/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Log Compression Cache misses/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Log Compressions/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Log Compressions/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Log Decompressions/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Log Decompressions/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Log remaining for undo</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Log remaining for undo&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Log Send Queue</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Log Send Queue&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Mirrored Write Transactions/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Mirrored Write Transactions/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Recovery Queue</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Recovery Queue&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Redo blocked/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Redo blocked/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Redo Bytes Remaining</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Redo Bytes Remaining&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Redone Bytes/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Redone Bytes/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes />
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Redones/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Redones/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Total Log requiring undo</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Total Log requiring undo&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Transaction Delay</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Transaction Delay&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL REPLICA</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}: Databases(_Total)\Percent Log Used</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Databases(_Total)\Percent Log Used&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL DATABASE</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST} DB {#DBNAME}: Active Transactions</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Active Transactions&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description>Number of active transactions for the database.</description>
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL DATABASE</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST} DB {#DBNAME}: Data File Size</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Data File(s) Size (KB)&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units>B</units>
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description>Cumulative size (in kilobytes) of all the data files in the database including any automatic growth. Monitoring this counter is useful, for example, for determining the correct size of tempdb.</description>
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing>
-                <step>
-                  <type>1</type>
-                  <params>1024</params>
-                </step>
-              </preprocessing>
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL DATABASE</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Bytes Flushed/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Log Bytes Flushed/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units>B</units>
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description>Total number of log bytes flushed per second. Useful for determining trends and utilization of the transaction log.</description>
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL DATABASE</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST} DB {#DBNAME}: Log File Size</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Log File(s) Size (KB)&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units>B</units>
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description>Cumulative size (in kilobytes) of all the transaction log files in the database.</description>
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing>
-                <step>
-                  <type>1</type>
-                  <params>1024</params>
-                </step>
-              </preprocessing>
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL DATABASE</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST} DB {#DBNAME}: Log File Used Size</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Log File(s) Used Size (KB)&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units>B</units>
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description>The cumulative used size of all the log files in the database.</description>
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing>
-                <step>
-                  <type>1</type>
-                  <params>1024</params>
-                </step>
-              </preprocessing>
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL DATABASE</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Flushes/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Log Flushes/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description>Number of log flushes per second.</description>
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL DATABASE</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Flush Waits/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Log Flush Waits/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description>Number of commits per second waiting for the log flush.</description>
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL DATABASE</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Flush Wait Time</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Log Flush Wait Time&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units>ms</units>
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description>Total wait time (in milliseconds) to flush the log. On an AlwaysOn secondary database, this value indicates the wait time for log records to be hardened to disk.</description>
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL DATABASE</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Growths</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Log Growths&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description>Total number of times the transaction log for the database has been expanded.</description>
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL DATABASE</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Shrinks</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Log Shrinks&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description>Total number of times the transaction log for the database has been shrunk.</description>
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL DATABASE</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Truncations</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Log Truncations&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>1</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description>The number of times the transaction log has been shrunk.</description>
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL DATABASE</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST} DB {#DBNAME}: Percent Log Used</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Percent Log Used&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units>%</units>
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description>Percentage of space in the log that is in use.</description>
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL DATABASE</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST} DB {#DBNAME}: Transactions per second</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Transactions/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL DATABASE</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:General Statistics\Processes Blocked</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:General Statistics\Processes Blocked&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL STATS</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:General Statistics\User Connections</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:General Statistics\User Connections&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL STATS</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:Locks(_Total)\Lock Timeouts/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Locks(_Total)\Lock Timeouts/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL LOCKS</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:Locks(_Total)\Number of Deadlocks/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Locks(_Total)\Number of Deadlocks/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL LOCKS</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:Memory Manager\Memory Grants Pending</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Memory Manager\Memory Grants Pending&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL MEMORY</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:Memory Manager\Target Server Memory (KB)</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Memory Manager\Target Server Memory (KB)&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units>KB</units>
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL MEMORY</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:Memory Manager\Total Server Memory (KB)</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Memory Manager\Total Server Memory (KB)&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units>KB</units>
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL MEMORY</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:SQL Statistics\Batch Requests/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:SQL Statistics\Batch Requests/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL STATS</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:SQL Statistics\SQL Compilations/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:SQL Statistics\SQL Compilations/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL STATS</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:SQL Statistics\SQL Re-Compilations/sec</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:SQL Statistics\SQL Re-Compilations/sec&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units />
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL STATS</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:Memory grant queue waits/Average wait time (ms)</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Average wait time (ms))\Memory grant queue waits&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units>ms</units>
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL WAITS</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:Network IO waits/Average wait time (ms)</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Average wait time (ms))\Network IO waits&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units>ms</units>
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL WAITS</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:Page IO latch waits/Average wait time (ms)</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Average wait time (ms))\Page IO latch waits&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units>ms</units>
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL WAITS</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:Memory grant queue waits/Cumulative wait time (ms) per second</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Cumulative wait time (ms) per second)\Memory grant queue waits&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units>ms</units>
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL WAITS</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:Network IO waits/Cumulative wait time (ms) per second</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Cumulative wait time (ms) per second)\Network IO waits&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units>ms</units>
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL WAITS</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:Page IO latch waits/Cumulative wait time (ms) per second</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Cumulative wait time (ms) per second)\Page IO latch waits&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units>ms</units>
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL WAITS</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:Memory grant queue waits/Waits in progress</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Waits in progress)\Memory grant queue waits&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units>ms</units>
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL WAITS</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:Network IO waits/Waits in progress</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Waits in progress)\Network IO waits&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units>ms</units>
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL WAITS</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:Page IO latch waits/Waits in progress</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Waits in progress)\Page IO latch waits&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units>ms</units>
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL WAITS</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:Memory grant queue waits/Waits started per second</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Waits started per second)\Memory grant queue waits&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units>ms</units>
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL WAITS</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:Network IO waits/Waits started per second</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Waits started per second)\Network IO waits&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units>ms</units>
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL WAITS</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-            <item_prototype>
-              <name>SQL Server Instance {#INST}:Page IO latch waits/Waits started per second</name>
-              <type>0</type>
-              <snmp_community />
-              <snmp_oid />
-              <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Waits started per second)\Page IO latch waits&quot;]</key>
-              <delay>1m</delay>
-              <history>90d</history>
-              <trends>365d</trends>
-              <status>0</status>
-              <value_type>0</value_type>
-              <allowed_hosts />
-              <units>ms</units>
-              <snmpv3_contextname />
-              <snmpv3_securityname />
-              <snmpv3_securitylevel>0</snmpv3_securitylevel>
-              <snmpv3_authprotocol>0</snmpv3_authprotocol>
-              <snmpv3_authpassphrase />
-              <snmpv3_privprotocol>0</snmpv3_privprotocol>
-              <snmpv3_privpassphrase />
-              <params />
-              <ipmi_sensor />
-              <authtype>0</authtype>
-              <username />
-              <password />
-              <publickey />
-              <privatekey />
-              <port />
-              <description />
-              <inventory_link>0</inventory_link>
-              <applications />
-              <valuemap />
-              <logtimefmt />
-              <preprocessing />
-              <jmx_endpoint />
-              <timeout>3s</timeout>
-              <url />
-              <query_fields />
-              <posts />
-              <status_codes>200</status_codes>
-              <follow_redirects>1</follow_redirects>
-              <post_type>0</post_type>
-              <http_proxy />
-              <headers />
-              <retrieve_mode>0</retrieve_mode>
-              <request_method>0</request_method>
-              <output_format>0</output_format>
-              <allow_traps>0</allow_traps>
-              <ssl_cert_file />
-              <ssl_key_file />
-              <ssl_key_password />
-              <verify_peer>0</verify_peer>
-              <verify_host>0</verify_host>
-              <application_prototypes>
-                <application_prototype>
-                  <name>MSSQL WAITS</name>
-                </application_prototype>
-              </application_prototypes>
-              <master_item />
-            </item_prototype>
-          </item_prototypes>
-          <trigger_prototypes />
-          <graph_prototypes />
-          <host_prototypes />
-          <jmx_endpoint />
-          <timeout>3s</timeout>
-          <url />
-          <query_fields />
-          <posts />
-          <status_codes>200</status_codes>
-          <follow_redirects>1</follow_redirects>
-          <post_type>0</post_type>
-          <http_proxy />
-          <headers />
-          <retrieve_mode>0</retrieve_mode>
-          <request_method>0</request_method>
-          <allow_traps>0</allow_traps>
-          <ssl_cert_file />
-          <ssl_key_file />
-          <ssl_key_password />
-          <verify_peer>0</verify_peer>
-          <verify_host>0</verify_host>
-        </discovery_rule>
-      </discovery_rules>
-      <httptests />
-      <macros />
-      <templates />
-      <screens />
-    </template>
-  </templates>
+    </groups>
+    <templates>
+        <template>
+            <template>Template App MSSQL 2008-2016</template>
+            <name>Template App MSSQL 2008-2016</name>
+            <description/>
+            <groups>
+                <group>
+                    <name>MSSQL Servers</name>
+                </group>
+                <group>
+                    <name>Templates</name>
+                </group>
+            </groups>
+            <applications/>
+            <items/>
+            <discovery_rules>
+                <discovery_rule>
+                    <name>Database Discovery - Default Instance</name>
+                    <type>0</type>
+                    <snmp_community/>
+                    <snmp_oid/>
+                    <key>mssql.default.db.discovery</key>
+                    <delay>1h</delay>
+                    <status>0</status>
+                    <allowed_hosts/>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <filter>
+                        <evaltype>0</evaltype>
+                        <formula/>
+                        <conditions/>
+                    </filter>
+                    <lifetime>30d</lifetime>
+                    <description/>
+                    <item_prototypes>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Database Status</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>mssql.default.dbstatus[{#INST},{#DBNAME}]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>0</trends>
+                            <status>0</status>
+                            <value_type>4</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL DATABASE</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Access Methods\Page Splits/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Access Methods\Page Splits/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL ACCESS METHODS</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Bytes Received from Replica/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Availability Replica(_Total)\Bytes Received from Replica/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Bytes Sent to Replica/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Availability Replica(_Total)\Bytes Sent to Replica/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Bytes Sent to Transport/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Availability Replica(_Total)\Bytes Sent to Transport/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Flow Control/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Availability Replica(_Total)\Flow Control/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Flow Control Time (ms/sec)</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Availability Replica(_Total)\Flow Control Time (ms/sec)&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Receives from Replica/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Availability Replica(_Total)\Receives from Replica/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Resent Messages/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Availability Replica(_Total)\Resent Messages/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Sends to Replica/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Availability Replica(_Total)\Sends to Replica/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Sends to Transport/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Availability Replica(_Total)\Sends to Transport/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Buffer Manager\Page life expectancy</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Buffer Manager\Page life expectancy&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL MEMORY</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Buffer Manager\Page reads/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Buffer Manager\Page reads/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL MEMORY</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Buffer Manager\Page writes/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Buffer Manager\Page writes/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL MEMORY</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Database Flow Control Delay</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Database Flow Control Delay&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Database Flow Controls/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Database Flow Controls/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: File Bytes Received/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\File Bytes Received/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Group Commits/Sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Group Commits/Sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Group Commit Time</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Group Commit Time&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Log Bytes Compressed/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Log Bytes Compressed/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Log Bytes Decompressed/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Log Bytes Decompressed/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Log Bytes Received/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Log Bytes Received/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Log Compression Cache hits/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Log Compression Cache hits/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Log Compression Cache misses/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Log Compression Cache misses/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Log Compressions/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Log Compressions/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Log Decompressions/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Log Decompressions/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Log remaining for undo</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Log remaining for undo&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Log Send Queue</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Log Send Queue&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Mirrored Write Transactions/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Mirrored Write Transactions/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Recovery Queue</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Recovery Queue&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Redo blocked/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Redo blocked/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Redo Bytes Remaining</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Redo Bytes Remaining&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Redone Bytes/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Redone Bytes/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes/>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Redones/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Redones/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Total Log requiring undo</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Total Log requiring undo&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Transaction Delay</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Transaction Delay&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Databases(_Total)\Percent Log Used</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Databases(_Total)\Percent Log Used&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL DATABASE</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Active Transactions</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Databases({#DBNAME})\Active Transactions&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description>Number of active transactions for the database.</description>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL DATABASE</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Data File Size</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Databases({#DBNAME})\Data File(s) Size (KB)&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>B</units>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description>Cumulative size (in kilobytes) of all the data files in the database including any automatic growth. Monitoring this counter is useful, for example, for determining the correct size of tempdb.</description>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing>
+                                <step>
+                                    <type>1</type>
+                                    <params>1024</params>
+                                </step>
+                            </preprocessing>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL DATABASE</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Bytes Flushed/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Databases({#DBNAME})\Log Bytes Flushed/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>B</units>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description>Total number of log bytes flushed per second. Useful for determining trends and utilization of the transaction log.</description>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL DATABASE</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Log File Size</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Databases({#DBNAME})\Log File(s) Size (KB)&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>B</units>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description>Cumulative size (in kilobytes) of all the transaction log files in the database.</description>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing>
+                                <step>
+                                    <type>1</type>
+                                    <params>1024</params>
+                                </step>
+                            </preprocessing>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL DATABASE</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Log File Used Size</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Databases({#DBNAME})\Log File(s) Used Size (KB)&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>B</units>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description>The cumulative used size of all the log files in the database.</description>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing>
+                                <step>
+                                    <type>1</type>
+                                    <params>1024</params>
+                                </step>
+                            </preprocessing>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL DATABASE</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Flushes/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Databases({#DBNAME})\Log Flushes/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description>Number of log flushes per second.</description>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL DATABASE</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Flush Waits/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Databases({#DBNAME})\Log Flush Waits/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description>Number of commits per second waiting for the log flush.</description>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL DATABASE</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Flush Wait Time</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Databases({#DBNAME})\Log Flush Wait Time&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>ms</units>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description>Total wait time (in milliseconds) to flush the log. On an AlwaysOn secondary database, this value indicates the wait time for log records to be hardened to disk.</description>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL DATABASE</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Growths</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Databases({#DBNAME})\Log Growths&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description>Total number of times the transaction log for the database has been expanded.</description>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL DATABASE</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Shrinks</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Databases({#DBNAME})\Log Shrinks&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description>Total number of times the transaction log for the database has been shrunk.</description>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL DATABASE</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Truncations</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Databases({#DBNAME})\Log Truncations&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description>The number of times the transaction log has been shrunk.</description>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL DATABASE</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Percent Log Used</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Databases({#DBNAME})\Percent Log Used&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>%</units>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description>Percentage of space in the log that is in use.</description>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL DATABASE</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Transactions per second</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Databases({#DBNAME})\Transactions/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL DATABASE</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:General Statistics\Processes Blocked</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:General Statistics\Processes Blocked&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL STATS</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:General Statistics\User Connections</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:General Statistics\User Connections&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL STATS</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:Locks(_Total)\Lock Timeouts/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Locks(_Total)\Lock Timeouts/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL LOCKS</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:Locks(_Total)\Number of Deadlocks/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Locks(_Total)\Number of Deadlocks/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL LOCKS</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:Memory Manager\Memory Grants Pending</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Memory Manager\Memory Grants Pending&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL MEMORY</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:Memory Manager\Target Server Memory (KB)</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Memory Manager\Target Server Memory (KB)&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>KB</units>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL MEMORY</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:Memory Manager\Total Server Memory (KB)</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Memory Manager\Total Server Memory (KB)&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>KB</units>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL MEMORY</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:SQL Statistics\Batch Requests/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:SQL Statistics\Batch Requests/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL STATS</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:SQL Statistics\SQL Compilations/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:SQL Statistics\SQL Compilations/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL STATS</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:SQL Statistics\SQL Re-Compilations/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:SQL Statistics\SQL Re-Compilations/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL STATS</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:Memory grant queue waits/Average wait time (ms)</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Wait Statistics(Average wait time (ms))\Memory grant queue waits&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>ms</units>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL WAITS</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:Network IO waits/Average wait time (ms)</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Wait Statistics(Average wait time (ms))\Network IO waits&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>ms</units>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL WAITS</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:Page IO latch waits/Average wait time (ms)</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Wait Statistics(Average wait time (ms))\Page IO latch waits&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>ms</units>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL WAITS</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:Memory grant queue waits/Cumulative wait time (ms) per second</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Wait Statistics(Cumulative wait time (ms) per second)\Memory grant queue waits&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>ms</units>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL WAITS</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:Network IO waits/Cumulative wait time (ms) per second</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Wait Statistics(Cumulative wait time (ms) per second)\Network IO waits&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>ms</units>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL WAITS</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:Page IO latch waits/Cumulative wait time (ms) per second</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Wait Statistics(Cumulative wait time (ms) per second)\Page IO latch waits&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>ms</units>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL WAITS</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:Memory grant queue waits/Waits in progress</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Wait Statistics(Waits in progress)\Memory grant queue waits&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>ms</units>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL WAITS</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:Network IO waits/Waits in progress</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Wait Statistics(Waits in progress)\Network IO waits&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>ms</units>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL WAITS</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:Page IO latch waits/Waits in progress</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Wait Statistics(Waits in progress)\Page IO latch waits&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>ms</units>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL WAITS</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:Memory grant queue waits/Waits started per second</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Wait Statistics(Waits started per second)\Memory grant queue waits&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>ms</units>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL WAITS</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:Network IO waits/Waits started per second</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Wait Statistics(Waits started per second)\Network IO waits&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>ms</units>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL WAITS</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:Page IO latch waits/Waits started per second</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\SQLServer:Wait Statistics(Waits started per second)\Page IO latch waits&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>ms</units>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL WAITS</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                    </item_prototypes>
+                    <trigger_prototypes/>
+                    <graph_prototypes/>
+                    <host_prototypes/>
+                    <jmx_endpoint/>
+                    <timeout>3s</timeout>
+                    <url/>
+                    <query_fields/>
+                    <posts/>
+                    <status_codes>200</status_codes>
+                    <follow_redirects>1</follow_redirects>
+                    <post_type>0</post_type>
+                    <http_proxy/>
+                    <headers/>
+                    <retrieve_mode>0</retrieve_mode>
+                    <request_method>0</request_method>
+                    <allow_traps>0</allow_traps>
+                    <ssl_cert_file/>
+                    <ssl_key_file/>
+                    <ssl_key_password/>
+                    <verify_peer>0</verify_peer>
+                    <verify_host>0</verify_host>
+                </discovery_rule>
+                <discovery_rule>
+                    <name>SQL Error Log</name>
+                    <type>0</type>
+                    <snmp_community/>
+                    <snmp_oid/>
+                    <key>mssql.errorlog</key>
+                    <delay>1h</delay>
+                    <status>0</status>
+                    <allowed_hosts/>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <filter>
+                        <evaltype>0</evaltype>
+                        <formula/>
+                        <conditions/>
+                    </filter>
+                    <lifetime>30d</lifetime>
+                    <description/>
+                    <item_prototypes>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Errors Logged Count</name>
+                            <type>7</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>log.count[{#ERRORLOG},Error|Failed,&quot;UTF-16&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>3</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL Error Log</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Errors Logged</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>mssql.errorlog.errors[{#INST},'{#ERRORLOG}']</key>
+                            <delay>30s</delay>
+                            <history>90d</history>
+                            <trends>0</trends>
+                            <status>0</status>
+                            <value_type>4</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL Error Log</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                    </item_prototypes>
+                    <trigger_prototypes>
+                        <trigger_prototype>
+                            <expression>{Template App MSSQL 2008-2016:log.count[{#ERRORLOG},Error|Failed,&quot;UTF-16&quot;].sum(5m)}&gt;0</expression>
+                            <recovery_mode>0</recovery_mode>
+                            <recovery_expression/>
+                            <name>Errors in {#IINST} ERRORLOG</name>
+                            <correlation_mode>0</correlation_mode>
+                            <correlation_tag/>
+                            <url/>
+                            <status>0</status>
+                            <priority>2</priority>
+                            <description/>
+                            <type>0</type>
+                            <manual_close>0</manual_close>
+                            <dependencies/>
+                            <tags/>
+                        </trigger_prototype>
+                        <trigger_prototype>
+                            <expression>{Template App MSSQL 2008-2016:log.count[{#ERRORLOG},Error|Failed,&quot;UTF-16&quot;].sum(5m)}&gt;0</expression>
+                            <recovery_mode>0</recovery_mode>
+                            <recovery_expression/>
+                            <name>Errors in {#INST} ERRORLOG</name>
+                            <correlation_mode>0</correlation_mode>
+                            <correlation_tag/>
+                            <url/>
+                            <status>0</status>
+                            <priority>2</priority>
+                            <description/>
+                            <type>0</type>
+                            <manual_close>0</manual_close>
+                            <dependencies/>
+                            <tags/>
+                        </trigger_prototype>
+                    </trigger_prototypes>
+                    <graph_prototypes/>
+                    <host_prototypes/>
+                    <jmx_endpoint/>
+                    <timeout>3s</timeout>
+                    <url/>
+                    <query_fields/>
+                    <posts/>
+                    <status_codes>200</status_codes>
+                    <follow_redirects>1</follow_redirects>
+                    <post_type>0</post_type>
+                    <http_proxy/>
+                    <headers/>
+                    <retrieve_mode>0</retrieve_mode>
+                    <request_method>0</request_method>
+                    <allow_traps>0</allow_traps>
+                    <ssl_cert_file/>
+                    <ssl_key_file/>
+                    <ssl_key_password/>
+                    <verify_peer>0</verify_peer>
+                    <verify_host>0</verify_host>
+                </discovery_rule>
+                <discovery_rule>
+                    <name>Database Discovery - Named Instances</name>
+                    <type>0</type>
+                    <snmp_community/>
+                    <snmp_oid/>
+                    <key>mssql.named.db.discovery</key>
+                    <delay>1h</delay>
+                    <status>0</status>
+                    <allowed_hosts/>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <filter>
+                        <evaltype>0</evaltype>
+                        <formula/>
+                        <conditions/>
+                    </filter>
+                    <lifetime>30d</lifetime>
+                    <description/>
+                    <item_prototypes>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Database Status</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>mssql.named.dbstatus[{#INST},{#DBNAME}]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>0</trends>
+                            <status>0</status>
+                            <value_type>4</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL DATABASE</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Access Methods\Page Splits/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Access Methods\Page Splits/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL ACCESS METHODS</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Bytes Received from Replica/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Availability Replica(_Total)\Bytes Received from Replica/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Bytes Sent to Replica/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Availability Replica(_Total)\Bytes Sent to Replica/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Bytes Sent to Transport/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Availability Replica(_Total)\Bytes Sent to Transport/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Flow Control/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Availability Replica(_Total)\Flow Control/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Flow Control Time (ms/sec)</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Availability Replica(_Total)\Flow Control Time (ms/sec)&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Receives from Replica/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Availability Replica(_Total)\Receives from Replica/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Resent Messages/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Availability Replica(_Total)\Resent Messages/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Sends to Replica/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Availability Replica(_Total)\Sends to Replica/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Sends to Transport/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Availability Replica(_Total)\Sends to Transport/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Buffer Manager\Page life expectancy</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Buffer Manager\Page life expectancy&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL MEMORY</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Buffer Manager\Page reads/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Buffer Manager\Page reads/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL MEMORY</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Buffer Manager\Page writes/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Buffer Manager\Page writes/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL MEMORY</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Database Flow Control Delay</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Database Flow Control Delay&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Database Flow Controls/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Database Flow Controls/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: File Bytes Received/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\File Bytes Received/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Group Commits/Sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Group Commits/Sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Group Commit Time</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Group Commit Time&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Log Bytes Compressed/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Log Bytes Compressed/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Log Bytes Decompressed/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Log Bytes Decompressed/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Log Bytes Received/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Log Bytes Received/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Log Compression Cache hits/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Log Compression Cache hits/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Log Compression Cache misses/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Log Compression Cache misses/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Log Compressions/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Log Compressions/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Log Decompressions/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Log Decompressions/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Log remaining for undo</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Log remaining for undo&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Log Send Queue</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Log Send Queue&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Mirrored Write Transactions/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Mirrored Write Transactions/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Recovery Queue</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Recovery Queue&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Redo blocked/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Redo blocked/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Redo Bytes Remaining</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Redo Bytes Remaining&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Redone Bytes/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Redone Bytes/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes/>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Redones/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Redones/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Total Log requiring undo</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Total Log requiring undo&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Transaction Delay</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Transaction Delay&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL REPLICA</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}: Databases(_Total)\Percent Log Used</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Databases(_Total)\Percent Log Used&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL DATABASE</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Active Transactions</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Active Transactions&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description>Number of active transactions for the database.</description>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL DATABASE</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Data File Size</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Data File(s) Size (KB)&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>B</units>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description>Cumulative size (in kilobytes) of all the data files in the database including any automatic growth. Monitoring this counter is useful, for example, for determining the correct size of tempdb.</description>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing>
+                                <step>
+                                    <type>1</type>
+                                    <params>1024</params>
+                                </step>
+                            </preprocessing>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL DATABASE</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Bytes Flushed/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Log Bytes Flushed/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>B</units>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description>Total number of log bytes flushed per second. Useful for determining trends and utilization of the transaction log.</description>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL DATABASE</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Log File Size</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Log File(s) Size (KB)&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>B</units>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description>Cumulative size (in kilobytes) of all the transaction log files in the database.</description>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing>
+                                <step>
+                                    <type>1</type>
+                                    <params>1024</params>
+                                </step>
+                            </preprocessing>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL DATABASE</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Log File Used Size</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Log File(s) Used Size (KB)&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>B</units>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description>The cumulative used size of all the log files in the database.</description>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing>
+                                <step>
+                                    <type>1</type>
+                                    <params>1024</params>
+                                </step>
+                            </preprocessing>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL DATABASE</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Flushes/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Log Flushes/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description>Number of log flushes per second.</description>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL DATABASE</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Flush Waits/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Log Flush Waits/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description>Number of commits per second waiting for the log flush.</description>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL DATABASE</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Flush Wait Time</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Log Flush Wait Time&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>ms</units>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description>Total wait time (in milliseconds) to flush the log. On an AlwaysOn secondary database, this value indicates the wait time for log records to be hardened to disk.</description>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL DATABASE</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Growths</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Log Growths&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description>Total number of times the transaction log for the database has been expanded.</description>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL DATABASE</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Shrinks</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Log Shrinks&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description>Total number of times the transaction log for the database has been shrunk.</description>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL DATABASE</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Truncations</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Log Truncations&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>1</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description>The number of times the transaction log has been shrunk.</description>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL DATABASE</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Percent Log Used</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Percent Log Used&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>%</units>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description>Percentage of space in the log that is in use.</description>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL DATABASE</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Transactions per second</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Transactions/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL DATABASE</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:General Statistics\Processes Blocked</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:General Statistics\Processes Blocked&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL STATS</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:General Statistics\User Connections</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:General Statistics\User Connections&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL STATS</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:Locks(_Total)\Lock Timeouts/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Locks(_Total)\Lock Timeouts/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL LOCKS</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:Locks(_Total)\Number of Deadlocks/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Locks(_Total)\Number of Deadlocks/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL LOCKS</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:Memory Manager\Memory Grants Pending</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Memory Manager\Memory Grants Pending&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL MEMORY</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:Memory Manager\Target Server Memory (KB)</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Memory Manager\Target Server Memory (KB)&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>KB</units>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL MEMORY</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:Memory Manager\Total Server Memory (KB)</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Memory Manager\Total Server Memory (KB)&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>KB</units>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL MEMORY</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:SQL Statistics\Batch Requests/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:SQL Statistics\Batch Requests/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL STATS</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:SQL Statistics\SQL Compilations/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:SQL Statistics\SQL Compilations/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL STATS</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:SQL Statistics\SQL Re-Compilations/sec</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:SQL Statistics\SQL Re-Compilations/sec&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL STATS</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:Memory grant queue waits/Average wait time (ms)</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Average wait time (ms))\Memory grant queue waits&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>ms</units>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL WAITS</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:Network IO waits/Average wait time (ms)</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Average wait time (ms))\Network IO waits&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>ms</units>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL WAITS</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:Page IO latch waits/Average wait time (ms)</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Average wait time (ms))\Page IO latch waits&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>ms</units>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL WAITS</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:Memory grant queue waits/Cumulative wait time (ms) per second</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Cumulative wait time (ms) per second)\Memory grant queue waits&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>ms</units>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL WAITS</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:Network IO waits/Cumulative wait time (ms) per second</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Cumulative wait time (ms) per second)\Network IO waits&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>ms</units>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL WAITS</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:Page IO latch waits/Cumulative wait time (ms) per second</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Cumulative wait time (ms) per second)\Page IO latch waits&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>ms</units>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL WAITS</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:Memory grant queue waits/Waits in progress</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Waits in progress)\Memory grant queue waits&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>ms</units>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL WAITS</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:Network IO waits/Waits in progress</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Waits in progress)\Network IO waits&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>ms</units>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL WAITS</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:Page IO latch waits/Waits in progress</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Waits in progress)\Page IO latch waits&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>ms</units>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL WAITS</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:Memory grant queue waits/Waits started per second</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Waits started per second)\Memory grant queue waits&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>ms</units>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL WAITS</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:Network IO waits/Waits started per second</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Waits started per second)\Network IO waits&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>ms</units>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL WAITS</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>SQL Server Instance {#INST}:Page IO latch waits/Waits started per second</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Waits started per second)\Page IO latch waits&quot;]</key>
+                            <delay>1m</delay>
+                            <history>90d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>ms</units>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <timeout>3s</timeout>
+                            <url/>
+                            <query_fields/>
+                            <posts/>
+                            <status_codes>200</status_codes>
+                            <follow_redirects>1</follow_redirects>
+                            <post_type>0</post_type>
+                            <http_proxy/>
+                            <headers/>
+                            <retrieve_mode>0</retrieve_mode>
+                            <request_method>0</request_method>
+                            <output_format>0</output_format>
+                            <allow_traps>0</allow_traps>
+                            <ssl_cert_file/>
+                            <ssl_key_file/>
+                            <ssl_key_password/>
+                            <verify_peer>0</verify_peer>
+                            <verify_host>0</verify_host>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>MSSQL WAITS</name>
+                                </application_prototype>
+                            </application_prototypes>
+                            <master_item/>
+                        </item_prototype>
+                    </item_prototypes>
+                    <trigger_prototypes/>
+                    <graph_prototypes/>
+                    <host_prototypes/>
+                    <jmx_endpoint/>
+                    <timeout>3s</timeout>
+                    <url/>
+                    <query_fields/>
+                    <posts/>
+                    <status_codes>200</status_codes>
+                    <follow_redirects>1</follow_redirects>
+                    <post_type>0</post_type>
+                    <http_proxy/>
+                    <headers/>
+                    <retrieve_mode>0</retrieve_mode>
+                    <request_method>0</request_method>
+                    <allow_traps>0</allow_traps>
+                    <ssl_cert_file/>
+                    <ssl_key_file/>
+                    <ssl_key_password/>
+                    <verify_peer>0</verify_peer>
+                    <verify_host>0</verify_host>
+                </discovery_rule>
+            </discovery_rules>
+            <httptests/>
+            <macros/>
+            <templates/>
+            <screens/>
+        </template>
+    </templates>
 </zabbix_export>

--- a/Template APP MSSQL 2008-2016.xml
+++ b/Template APP MSSQL 2008-2016.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
     <version>4.0</version>
-    <date>2019-07-05T17:22:53Z</date>
+    <date>2019-07-05T19:15:50Z</date>
     <groups>
         <group>
             <name>MSSQL Servers</name>
@@ -4449,7 +4449,7 @@
                             <type>7</type>
                             <snmp_community/>
                             <snmp_oid/>
-                            <key>log.count[{#ERRORLOG},Error|Failed,&quot;UTF-16&quot;]</key>
+                            <key>log.count[{#ERRORLOG},Error,&quot;UTF-16&quot;]</key>
                             <delay>1m</delay>
                             <history>90d</history>
                             <trends>365d</trends>
@@ -4567,18 +4567,34 @@
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{Template App MSSQL 2008-2016:log.count[{#ERRORLOG},Error|Failed,&quot;UTF-16&quot;].sum(5m)}&gt;0</expression>
-                            <recovery_mode>0</recovery_mode>
+                            <expression>{Template App MSSQL 2008-2016:mssql.errorlog.errors[{#INST},'{#ERRORLOG}'].iregexp(&quot;Severity:\s(?:1[8-9]|20)&quot;)}&lt;&gt;0</expression>
+                            <recovery_mode>2</recovery_mode>
                             <recovery_expression/>
-                            <name>Errors in {#INST} ERRORLOG</name>
+                            <name>SQL Server {#INST} Errors Logged</name>
                             <correlation_mode>0</correlation_mode>
                             <correlation_tag/>
                             <url/>
                             <status>0</status>
                             <priority>2</priority>
                             <description/>
-                            <type>0</type>
-                            <manual_close>0</manual_close>
+                            <type>1</type>
+                            <manual_close>1</manual_close>
+                            <dependencies/>
+                            <tags/>
+                        </trigger_prototype>
+                        <trigger_prototype>
+                            <expression>{Template App MSSQL 2008-2016:mssql.errorlog.errors[{#INST},'{#ERRORLOG}'].iregexp(&quot;Severity:\s(?:2[1-4])&quot;)}&lt;&gt;0</expression>
+                            <recovery_mode>2</recovery_mode>
+                            <recovery_expression/>
+                            <name>SQL Server {#INST} Severe Errors Logged</name>
+                            <correlation_mode>0</correlation_mode>
+                            <correlation_tag/>
+                            <url/>
+                            <status>0</status>
+                            <priority>4</priority>
+                            <description/>
+                            <type>1</type>
+                            <manual_close>1</manual_close>
                             <dependencies/>
                             <tags/>
                         </trigger_prototype>

--- a/Template APP MSSQL 2008-2016.xml
+++ b/Template APP MSSQL 2008-2016.xml
@@ -1,3190 +1,9000 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
-    <version>3.4</version>
-    <date>2018-04-26T13:25:36Z</date>
-    <groups>
+  <version>4.0</version>
+  <date>2019-06-28T15:54:11Z</date>
+  <groups>
+    <group>
+      <name>MSSQL Servers</name>
+    </group>
+    <group>
+      <name>Templates</name>
+    </group>
+  </groups>
+  <templates>
+    <template>
+      <template>Template App MSSQL 2008-2016</template>
+      <name>Template App MSSQL 2008-2016</name>
+      <description />
+      <groups>
         <group>
-            <name>Templates</name>
+          <name>MSSQL Servers</name>
         </group>
-    </groups>
-    <templates>
-        <template>
-            <template>Template App MSSQL 2008-2016</template>
-            <name>Template App MSSQL 2008-2016</name>
-            <description/>
-            <groups>
-                <group>
-                    <name>Templates</name>
-                </group>
-            </groups>
-            <applications/>
-            <items/>
-            <discovery_rules>
-                <discovery_rule>
-                    <name>Database Discovery</name>
-                    <type>0</type>
-                    <snmp_community/>
-                    <snmp_oid/>
-                    <key>mssql.db.discovery</key>
-                    <delay>1h</delay>
-                    <status>0</status>
-                    <allowed_hosts/>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <filter>
-                        <evaltype>0</evaltype>
-                        <formula/>
-                        <conditions>
-                            <condition>
-                                <macro>{#DBNAME}</macro>
-                                <value>@Databases for discovery</value>
-                                <operator>8</operator>
-                                <formulaid>A</formulaid>
-                            </condition>
-                        </conditions>
-                    </filter>
-                    <lifetime>30d</lifetime>
-                    <description/>
-                    <item_prototypes>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}: Access Methods\Page Splits/sec</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Access Methods\Page Splits/sec&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL ACCESS METHODS</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}: Bytes Received from Replica/sec</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Availability Replica(_Total)\Bytes Received from Replica/sec&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL REPLICA</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}: Bytes Sent to Replica/sec</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Availability Replica(_Total)\Bytes Sent to Replica/sec&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL REPLICA</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}: Bytes Sent to Transport/sec</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Availability Replica(_Total)\Bytes Sent to Transport/sec&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL REPLICA</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}: Flow Control/sec</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Availability Replica(_Total)\Flow Control/sec&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL REPLICA</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}: Flow Control Time (ms/sec)</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Availability Replica(_Total)\Flow Control Time (ms/sec)&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL REPLICA</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}: Receives from Replica/sec</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Availability Replica(_Total)\Receives from Replica/sec&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL REPLICA</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}: Resent Messages/sec</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Availability Replica(_Total)\Resent Messages/sec&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL REPLICA</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}: Sends to Replica/sec</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Availability Replica(_Total)\Sends to Replica/sec&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL REPLICA</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}: Sends to Transport/sec</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Availability Replica(_Total)\Sends to Transport/sec&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL REPLICA</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}: Buffer Manager\Page life expectancy</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Buffer Manager\Page life expectancy&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL MEMORY</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}: Buffer Manager\Page reads/sec</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Buffer Manager\Page reads/sec&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL MEMORY</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}: Buffer Manager\Page writes/sec</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Buffer Manager\Page writes/sec&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL MEMORY</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}: Database Flow Control Delay</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Database Flow Control Delay&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes/>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}: Database Flow Controls/sec</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Database Flow Controls/sec&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL REPLICA</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}: File Bytes Received/sec</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\File Bytes Received/sec&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes/>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}: Group Commits/Sec</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Group Commits/Sec&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes/>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}: Group Commit Time</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Group Commit Time&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes/>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}: Log Bytes Compressed/sec</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Log Bytes Compressed/sec&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes/>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}: Log Bytes Decompressed/sec</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Log Bytes Decompressed/sec&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes/>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}: Log Bytes Received/sec</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Log Bytes Received/sec&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes/>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}: Log Compression Cache hits/sec</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Log Compression Cache hits/sec&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL REPLICA</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}: Log Compression Cache misses/sec</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Log Compression Cache misses/sec&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes/>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}: Log Compressions/sec</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Log Compressions/sec&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes/>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}: Log Decompressions/sec</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Log Decompressions/sec&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes/>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}: Log remaining for undo</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Log remaining for undo&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes/>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}: Log Send Queue</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Log Send Queue&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL REPLICA</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}: Mirrored Write Transactions/sec</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Mirrored Write Transactions/sec&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes/>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}: Recovery Queue</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Recovery Queue&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL REPLICA</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}: Redo blocked/sec</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Redo blocked/sec&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes/>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}: Redo Bytes Remaining</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Redo Bytes Remaining&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes/>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}: Redone Bytes/sec</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Redone Bytes/sec&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes/>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}: Redones/sec</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Redones/sec&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes/>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}: Total Log requiring undo</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Total Log requiring undo&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes/>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}: Transaction Delay</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Transaction Delay&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes/>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}: Databases(_Total)\Percent Log Used</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Databases(_Total)\Percent Log Used&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL DATABASE</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Active Transactions</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Active Transactions&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>0</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description>Number of active transactions for the database.</description>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL DATABASE</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Data File Size</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Data File(s) Size (KB)&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>0</value_type>
-                            <allowed_hosts/>
-                            <units>B</units>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description>Cumulative size (in kilobytes) of all the data files in the database including any automatic growth. Monitoring this counter is useful, for example, for determining the correct size of tempdb.</description>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing>
-                                <step>
-                                    <type>1</type>
-                                    <params>1024</params>
-                                </step>
-                            </preprocessing>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL DATABASE</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Bytes Flushed/sec</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Log Bytes Flushed/sec&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>0</value_type>
-                            <allowed_hosts/>
-                            <units>B</units>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description>Total number of log bytes flushed per second. Useful for determining trends and utilization of the transaction log.</description>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes/>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Log File Size</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Log File(s) Size (KB)&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>0</value_type>
-                            <allowed_hosts/>
-                            <units>B</units>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description>Cumulative size (in kilobytes) of all the transaction log files in the database.</description>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing>
-                                <step>
-                                    <type>1</type>
-                                    <params>1024</params>
-                                </step>
-                            </preprocessing>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL DATABASE</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Log File Used Size</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Log File(s) Used Size (KB)&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>0</value_type>
-                            <allowed_hosts/>
-                            <units>B</units>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description>The cumulative used size of all the log files in the database.</description>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing>
-                                <step>
-                                    <type>1</type>
-                                    <params>1024</params>
-                                </step>
-                            </preprocessing>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL DATABASE</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Flushes/sec</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Log Flushes/sec&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>0</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description>Number of log flushes per second.</description>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes/>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Flush Waits/sec</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Log Flush Waits/sec&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>0</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description>Number of commits per second waiting for the log flush.</description>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes/>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Flush Wait Time</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Log Flush Wait Time&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>0</value_type>
-                            <allowed_hosts/>
-                            <units>ms</units>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description>Total wait time (in milliseconds) to flush the log. On an AlwaysOn secondary database, this value indicates the wait time for log records to be hardened to disk.</description>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes/>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Growths</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Log Growths&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>0</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description>Total number of times the transaction log for the database has been expanded.</description>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes/>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Shrinks</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Log Shrinks&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>0</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description>Total number of times the transaction log for the database has been shrunk.</description>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes/>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Truncations</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Log Truncations&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>0</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description>The number of times the transaction log has been shrunk.</description>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes/>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Percent Log Used</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Percent Log Used&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>0</value_type>
-                            <allowed_hosts/>
-                            <units>%</units>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description>Percentage of space in the log that is in use.</description>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes/>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Transactions per second</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Transactions/sec&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>0</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes/>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}:General Statistics\User Connections</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:General Statistics\User Connections&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL STATS</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}:General Statistics\Processes Blocked</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:General Statistics\Processes Blocked&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL STATS</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}:Locks(_Total)\Lock Timeouts/sec</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Locks(_Total)\Lock Timeouts/sec&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL LOCKS</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}:Locks(_Total)\Number of Deadlocks/sec</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Locks(_Total)\Number of Deadlocks/sec&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL LOCKS</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}:Memory Manager\Memory Grants Pending</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Memory Manager\Memory Grants Pending&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL MEMORY</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}:Memory Manager\Target Server Memory (KB)</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Memory Manager\Target Server Memory (KB)&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units>KB</units>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL MEMORY</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}:Memory Manager\Total Server Memory (KB)</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Memory Manager\Total Server Memory (KB)&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units>KB</units>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL MEMORY</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}:SQL Statistics\Batch Requests/sec</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:SQL Statistics\Batch Requests/sec&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>0</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL STATS</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}:SQL Statistics\SQL Compilations/sec</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:SQL Statistics\SQL Compilations/sec&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>0</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL STATS</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}:SQL Statistics\SQL Re-Compilations/sec</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:SQL Statistics\SQL Re-Compilations/sec&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL STATS</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}:Memory grant queue waits/Average wait time (ms)</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Average wait time (ms))\Memory grant queue waits&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units>ms</units>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL WAITS</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}:Network IO waits/Average wait time (ms)</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Average wait time (ms))\Network IO waits&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units>ms</units>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL WAITS</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}:Page IO latch waits/Average wait time (ms)</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Average wait time (ms))\Page IO latch waits&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units>ms</units>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL WAITS</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}:Memory grant queue waits/Cumulative wait time (ms) per second</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Cumulative wait time (ms) per second)\Memory grant queue waits&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units>ms</units>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL WAITS</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}:Network IO waits/Cumulative wait time (ms) per second</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Cumulative wait time (ms) per second)\Network IO waits&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units>ms</units>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL WAITS</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}:Page IO latch waits/Cumulative wait time (ms) per second</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Cumulative wait time (ms) per second)\Page IO latch waits&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units>ms</units>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL WAITS</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}:Memory grant queue waits/Waits in progress</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Waits in progress)\Memory grant queue waits&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units>ms</units>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL WAITS</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}:Network IO waits/Waits in progress</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Waits in progress)\Network IO waits&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units>ms</units>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL WAITS</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}:Page IO latch waits/Waits in progress</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Waits in progress)\Page IO latch waits&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units>ms</units>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL WAITS</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}:Memory grant queue waits/Waits started per second</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Waits started per second)\Memory grant queue waits&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units>ms</units>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL WAITS</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}:Network IO waits/Waits started per second</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Waits started per second)\Network IO waits&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units>ms</units>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL WAITS</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}:Page IO latch waits/Waits started per second</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Waits started per second)\Page IO latch waits&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units>ms</units>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL WAITS</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST} DB {#DBNAME}: Database Status</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>mssql.dbstatus</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>0</trends>
-                            <status>0</status>
-                            <value_type>4</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL DATABASE</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                    </item_prototypes>
-                    <trigger_prototypes>
-                        <trigger_prototype>
-                            <expression>{Template App MSSQL 2008-2016:system.run[&quot;powershell C:\'Program Files'\'Zabbix Agent'\scripts\database_status_disc.ps1 -instName '{#INST}' -dbName '{#DBNAME}'&quot;].iregexp(ONLINE,15m)}=0</expression>
-                            <recovery_mode>0</recovery_mode>
-                            <recovery_expression/>
-                            <name>Database - {#DBNAME} on Instance {#INST} is not running</name>
-                            <correlation_mode>0</correlation_mode>
-                            <correlation_tag/>
-                            <url/>
-                            <status>0</status>
-                            <priority>4</priority>
-                            <description>EC tag is for Event Correlation.&#13;
-Setup a rule for &quot;event tag pair&quot;, use EC=EC, and set operation to close new event. This way only one event per database remains open.</description>
-                            <type>0</type>
-                            <manual_close>0</manual_close>
-                            <dependencies/>
-                            <tags>
-                                <tag>
-                                    <tag>EC</tag>
-                                    <value>{#DBNAME}</value>
-                                </tag>
-                            </tags>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                            <expression>{Template App MSSQL 2008-2016:system.run[&quot;powershell C:\'Program Files'\'Zabbix Agent'\scripts\database_status_disc.ps1 -instName '{#INST}' -dbName '{#DBNAME}'&quot;].nodata(30m)}=1</expression>
-                            <recovery_mode>0</recovery_mode>
-                            <recovery_expression/>
-                            <name>Database - {#DBNAME} on Instance {#INST} Users Cannot Connect</name>
-                            <correlation_mode>0</correlation_mode>
-                            <correlation_tag/>
-                            <url/>
-                            <status>0</status>
-                            <priority>4</priority>
-                            <description>EC tag is for Event Correlation.&#13;
-Setup a rule for &quot;event tag pair&quot;, use EC=EC, and set operation to close new event. This way only one event per database remains open.</description>
-                            <type>0</type>
-                            <manual_close>0</manual_close>
-                            <dependencies/>
-                            <tags>
-                                <tag>
-                                    <tag>EC</tag>
-                                    <value>{#DBNAME}</value>
-                                </tag>
-                            </tags>
-                        </trigger_prototype>
-                    </trigger_prototypes>
-                    <graph_prototypes/>
-                    <host_prototypes/>
-                    <jmx_endpoint/>
-                </discovery_rule>
-                <discovery_rule>
-                    <name>SQL Error Log</name>
-                    <type>0</type>
-                    <snmp_community/>
-                    <snmp_oid/>
-                    <key>mssql.errorlog</key>
-                    <delay>1h</delay>
-                    <status>0</status>
-                    <allowed_hosts/>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <filter>
-                        <evaltype>0</evaltype>
-                        <formula/>
-                        <conditions/>
-                    </filter>
-                    <lifetime>30d</lifetime>
-                    <description/>
-                    <item_prototypes>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}: Error Log File (LOGCount)</name>
-                            <type>7</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>log.count[{#ERRORLOG},Error|Failed,&quot;UTF-16&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL Error Log</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>SQL Server Instance {#INST}: Error Log File (LOG)</name>
-                            <type>7</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>log[{#ERRORLOG},Error|Failed,&quot;UTF-16&quot;]</key>
-                            <delay>1m</delay>
-                            <history>90d</history>
-                            <trends>0</trends>
-                            <status>0</status>
-                            <value_type>2</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <application_prototypes>
-                                <application_prototype>
-                                    <name>MSSQL Error Log</name>
-                                </application_prototype>
-                            </application_prototypes>
-                            <master_item_prototype/>
-                        </item_prototype>
-                    </item_prototypes>
-                    <trigger_prototypes>
-                        <trigger_prototype>
-                            <expression>{Template App MSSQL 2008-2016:log.count[{#ERRORLOG},Error|Failed,&quot;UTF-16&quot;].sum(5m)}&gt;0</expression>
-                            <recovery_mode>0</recovery_mode>
-                            <recovery_expression/>
-                            <name>Errors in {#IINST} ERRORLOG</name>
-                            <correlation_mode>0</correlation_mode>
-                            <correlation_tag/>
-                            <url/>
-                            <status>0</status>
-                            <priority>2</priority>
-                            <description/>
-                            <type>0</type>
-                            <manual_close>0</manual_close>
-                            <dependencies/>
-                            <tags/>
-                        </trigger_prototype>
-                    </trigger_prototypes>
-                    <graph_prototypes/>
-                    <host_prototypes/>
-                    <jmx_endpoint/>
-                </discovery_rule>
-            </discovery_rules>
-            <httptests/>
-            <macros/>
-            <templates/>
-            <screens/>
-        </template>
-    </templates>
+        <group>
+          <name>Templates</name>
+        </group>
+      </groups>
+      <applications />
+      <items />
+      <discovery_rules>
+        <discovery_rule>
+          <name>Database Discovery - Default Instance</name>
+          <type>0</type>
+          <snmp_community />
+          <snmp_oid />
+          <key>mssql.default.db.discovery</key>
+          <delay>1h</delay>
+          <status>0</status>
+          <allowed_hosts />
+          <snmpv3_contextname />
+          <snmpv3_securityname />
+          <snmpv3_securitylevel>0</snmpv3_securitylevel>
+          <snmpv3_authprotocol>0</snmpv3_authprotocol>
+          <snmpv3_authpassphrase />
+          <snmpv3_privprotocol>0</snmpv3_privprotocol>
+          <snmpv3_privpassphrase />
+          <params />
+          <ipmi_sensor />
+          <authtype>0</authtype>
+          <username />
+          <password />
+          <publickey />
+          <privatekey />
+          <port />
+          <filter>
+            <evaltype>0</evaltype>
+            <formula />
+            <conditions />
+          </filter>
+          <lifetime>30d</lifetime>
+          <description />
+          <item_prototypes>
+            <item_prototype>
+              <name>SQL Server Instance {#INST} DB {#DBNAME}: Database Status</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>mssql.default.dbstatus[{#INST},{#DBNAME}]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>0</trends>
+              <status>0</status>
+              <value_type>4</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL DATABASE</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Access Methods\Page Splits/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Access Methods\Page Splits/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL ACCESS METHODS</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Bytes Received from Replica/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Availability Replica(_Total)\Bytes Received from Replica/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Bytes Sent to Replica/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Availability Replica(_Total)\Bytes Sent to Replica/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Bytes Sent to Transport/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Availability Replica(_Total)\Bytes Sent to Transport/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Flow Control/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Availability Replica(_Total)\Flow Control/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Flow Control Time (ms/sec)</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Availability Replica(_Total)\Flow Control Time (ms/sec)&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Receives from Replica/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Availability Replica(_Total)\Receives from Replica/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Resent Messages/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Availability Replica(_Total)\Resent Messages/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Sends to Replica/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Availability Replica(_Total)\Sends to Replica/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Sends to Transport/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Availability Replica(_Total)\Sends to Transport/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Buffer Manager\Page life expectancy</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Buffer Manager\Page life expectancy&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL MEMORY</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Buffer Manager\Page reads/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Buffer Manager\Page reads/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL MEMORY</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Buffer Manager\Page writes/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Buffer Manager\Page writes/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL MEMORY</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Database Flow Control Delay</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Database Flow Control Delay&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Database Flow Controls/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Database Flow Controls/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: File Bytes Received/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\File Bytes Received/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Group Commits/Sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Group Commits/Sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Group Commit Time</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Group Commit Time&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Log Bytes Compressed/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Log Bytes Compressed/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Log Bytes Decompressed/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Log Bytes Decompressed/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Log Bytes Received/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Log Bytes Received/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Log Compression Cache hits/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Log Compression Cache hits/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Log Compression Cache misses/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Log Compression Cache misses/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Log Compressions/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Log Compressions/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Log Decompressions/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Log Decompressions/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Log remaining for undo</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Log remaining for undo&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Log Send Queue</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Log Send Queue&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Mirrored Write Transactions/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Mirrored Write Transactions/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Recovery Queue</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Recovery Queue&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Redo blocked/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Redo blocked/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Redo Bytes Remaining</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Redo Bytes Remaining&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Redone Bytes/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Redone Bytes/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes />
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Redones/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Redones/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Total Log requiring undo</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Total Log requiring undo&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Transaction Delay</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Database Replica(_Total)\Transaction Delay&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Databases(_Total)\Percent Log Used</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Databases(_Total)\Percent Log Used&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL DATABASE</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST} DB {#DBNAME}: Active Transactions</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Databases({#DBNAME})\Active Transactions&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description>Number of active transactions for the database.</description>
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL DATABASE</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST} DB {#DBNAME}: Data File Size</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Databases({#DBNAME})\Data File(s) Size (KB)&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units>B</units>
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description>Cumulative size (in kilobytes) of all the data files in the database including any automatic growth. Monitoring this counter is useful, for example, for determining the correct size of tempdb.</description>
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing>
+                <step>
+                  <type>1</type>
+                  <params>1024</params>
+                </step>
+              </preprocessing>
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL DATABASE</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Bytes Flushed/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Databases({#DBNAME})\Log Bytes Flushed/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units>B</units>
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description>Total number of log bytes flushed per second. Useful for determining trends and utilization of the transaction log.</description>
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL DATABASE</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST} DB {#DBNAME}: Log File Size</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Databases({#DBNAME})\Log File(s) Size (KB)&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units>B</units>
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description>Cumulative size (in kilobytes) of all the transaction log files in the database.</description>
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing>
+                <step>
+                  <type>1</type>
+                  <params>1024</params>
+                </step>
+              </preprocessing>
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL DATABASE</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST} DB {#DBNAME}: Log File Used Size</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Databases({#DBNAME})\Log File(s) Used Size (KB)&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units>B</units>
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description>The cumulative used size of all the log files in the database.</description>
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing>
+                <step>
+                  <type>1</type>
+                  <params>1024</params>
+                </step>
+              </preprocessing>
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL DATABASE</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Flushes/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Databases({#DBNAME})\Log Flushes/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description>Number of log flushes per second.</description>
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL DATABASE</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Flush Waits/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Databases({#DBNAME})\Log Flush Waits/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description>Number of commits per second waiting for the log flush.</description>
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL DATABASE</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Flush Wait Time</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Databases({#DBNAME})\Log Flush Wait Time&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units>ms</units>
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description>Total wait time (in milliseconds) to flush the log. On an AlwaysOn secondary database, this value indicates the wait time for log records to be hardened to disk.</description>
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL DATABASE</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Growths</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Databases({#DBNAME})\Log Growths&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description>Total number of times the transaction log for the database has been expanded.</description>
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL DATABASE</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Shrinks</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Databases({#DBNAME})\Log Shrinks&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description>Total number of times the transaction log for the database has been shrunk.</description>
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL DATABASE</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Truncations</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Databases({#DBNAME})\Log Truncations&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description>The number of times the transaction log has been shrunk.</description>
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL DATABASE</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST} DB {#DBNAME}: Percent Log Used</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Databases({#DBNAME})\Percent Log Used&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units>%</units>
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description>Percentage of space in the log that is in use.</description>
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL DATABASE</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST} DB {#DBNAME}: Transactions per second</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Databases({#DBNAME})\Transactions/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL DATABASE</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:General Statistics\Processes Blocked</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:General Statistics\Processes Blocked&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL STATS</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:General Statistics\User Connections</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:General Statistics\User Connections&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL STATS</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:Locks(_Total)\Lock Timeouts/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Locks(_Total)\Lock Timeouts/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL LOCKS</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:Locks(_Total)\Number of Deadlocks/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Locks(_Total)\Number of Deadlocks/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL LOCKS</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:Memory Manager\Memory Grants Pending</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Memory Manager\Memory Grants Pending&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL MEMORY</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:Memory Manager\Target Server Memory (KB)</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Memory Manager\Target Server Memory (KB)&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units>KB</units>
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL MEMORY</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:Memory Manager\Total Server Memory (KB)</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Memory Manager\Total Server Memory (KB)&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units>KB</units>
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL MEMORY</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:SQL Statistics\Batch Requests/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:SQL Statistics\Batch Requests/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL STATS</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:SQL Statistics\SQL Compilations/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:SQL Statistics\SQL Compilations/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL STATS</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:SQL Statistics\SQL Re-Compilations/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:SQL Statistics\SQL Re-Compilations/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL STATS</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:Memory grant queue waits/Average wait time (ms)</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Wait Statistics(Average wait time (ms))\Memory grant queue waits&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units>ms</units>
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL WAITS</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:Network IO waits/Average wait time (ms)</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Wait Statistics(Average wait time (ms))\Network IO waits&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units>ms</units>
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL WAITS</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:Page IO latch waits/Average wait time (ms)</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Wait Statistics(Average wait time (ms))\Page IO latch waits&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units>ms</units>
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL WAITS</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:Memory grant queue waits/Cumulative wait time (ms) per second</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Wait Statistics(Cumulative wait time (ms) per second)\Memory grant queue waits&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units>ms</units>
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL WAITS</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:Network IO waits/Cumulative wait time (ms) per second</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Wait Statistics(Cumulative wait time (ms) per second)\Network IO waits&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units>ms</units>
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL WAITS</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:Page IO latch waits/Cumulative wait time (ms) per second</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Wait Statistics(Cumulative wait time (ms) per second)\Page IO latch waits&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units>ms</units>
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL WAITS</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:Memory grant queue waits/Waits in progress</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Wait Statistics(Waits in progress)\Memory grant queue waits&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units>ms</units>
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL WAITS</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:Network IO waits/Waits in progress</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Wait Statistics(Waits in progress)\Network IO waits&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units>ms</units>
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL WAITS</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:Page IO latch waits/Waits in progress</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Wait Statistics(Waits in progress)\Page IO latch waits&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units>ms</units>
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL WAITS</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:Memory grant queue waits/Waits started per second</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Wait Statistics(Waits started per second)\Memory grant queue waits&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units>ms</units>
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL WAITS</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:Network IO waits/Waits started per second</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Wait Statistics(Waits started per second)\Network IO waits&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units>ms</units>
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL WAITS</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:Page IO latch waits/Waits started per second</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\SQLServer:Wait Statistics(Waits started per second)\Page IO latch waits&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units>ms</units>
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL WAITS</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+          </item_prototypes>
+          <trigger_prototypes />
+          <graph_prototypes />
+          <host_prototypes />
+          <jmx_endpoint />
+          <timeout>3s</timeout>
+          <url />
+          <query_fields />
+          <posts />
+          <status_codes>200</status_codes>
+          <follow_redirects>1</follow_redirects>
+          <post_type>0</post_type>
+          <http_proxy />
+          <headers />
+          <retrieve_mode>0</retrieve_mode>
+          <request_method>0</request_method>
+          <allow_traps>0</allow_traps>
+          <ssl_cert_file />
+          <ssl_key_file />
+          <ssl_key_password />
+          <verify_peer>0</verify_peer>
+          <verify_host>0</verify_host>
+        </discovery_rule>
+        <discovery_rule>
+          <name>SQL Error Log</name>
+          <type>0</type>
+          <snmp_community />
+          <snmp_oid />
+          <key>mssql.errorlog</key>
+          <delay>1h</delay>
+          <status>0</status>
+          <allowed_hosts />
+          <snmpv3_contextname />
+          <snmpv3_securityname />
+          <snmpv3_securitylevel>0</snmpv3_securitylevel>
+          <snmpv3_authprotocol>0</snmpv3_authprotocol>
+          <snmpv3_authpassphrase />
+          <snmpv3_privprotocol>0</snmpv3_privprotocol>
+          <snmpv3_privpassphrase />
+          <params />
+          <ipmi_sensor />
+          <authtype>0</authtype>
+          <username />
+          <password />
+          <publickey />
+          <privatekey />
+          <port />
+          <filter>
+            <evaltype>0</evaltype>
+            <formula />
+            <conditions />
+          </filter>
+          <lifetime>30d</lifetime>
+          <description />
+          <item_prototypes>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Error Log File (LOGCount)</name>
+              <type>7</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>log.count[{#ERRORLOG},Error|Failed,&quot;UTF-16&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>3</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL Error Log</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Error Log File (LOG)</name>
+              <type>7</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>log[{#ERRORLOG},Error|Failed,&quot;UTF-16&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>0</trends>
+              <status>0</status>
+              <value_type>2</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL Error Log</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+          </item_prototypes>
+          <trigger_prototypes>
+            <trigger_prototype>
+              <expression>{Template App MSSQL 2008-2016:log.count[{#ERRORLOG},Error|Failed,&quot;UTF-16&quot;].sum(5m)}&gt;0</expression>
+              <recovery_mode>0</recovery_mode>
+              <recovery_expression />
+              <name>Errors in {#IINST} ERRORLOG</name>
+              <correlation_mode>0</correlation_mode>
+              <correlation_tag />
+              <url />
+              <status>0</status>
+              <priority>2</priority>
+              <description />
+              <type>0</type>
+              <manual_close>0</manual_close>
+              <dependencies />
+              <tags />
+            </trigger_prototype>
+          </trigger_prototypes>
+          <graph_prototypes />
+          <host_prototypes />
+          <jmx_endpoint />
+          <timeout>3s</timeout>
+          <url />
+          <query_fields />
+          <posts />
+          <status_codes>200</status_codes>
+          <follow_redirects>1</follow_redirects>
+          <post_type>0</post_type>
+          <http_proxy />
+          <headers />
+          <retrieve_mode>0</retrieve_mode>
+          <request_method>0</request_method>
+          <allow_traps>0</allow_traps>
+          <ssl_cert_file />
+          <ssl_key_file />
+          <ssl_key_password />
+          <verify_peer>0</verify_peer>
+          <verify_host>0</verify_host>
+        </discovery_rule>
+        <discovery_rule>
+          <name>Database Discovery - Named Instances</name>
+          <type>0</type>
+          <snmp_community />
+          <snmp_oid />
+          <key>mssql.named.db.discovery</key>
+          <delay>1h</delay>
+          <status>0</status>
+          <allowed_hosts />
+          <snmpv3_contextname />
+          <snmpv3_securityname />
+          <snmpv3_securitylevel>0</snmpv3_securitylevel>
+          <snmpv3_authprotocol>0</snmpv3_authprotocol>
+          <snmpv3_authpassphrase />
+          <snmpv3_privprotocol>0</snmpv3_privprotocol>
+          <snmpv3_privpassphrase />
+          <params />
+          <ipmi_sensor />
+          <authtype>0</authtype>
+          <username />
+          <password />
+          <publickey />
+          <privatekey />
+          <port />
+          <filter>
+            <evaltype>0</evaltype>
+            <formula />
+            <conditions />
+          </filter>
+          <lifetime>30d</lifetime>
+          <description />
+          <item_prototypes>
+            <item_prototype>
+              <name>SQL Server Instance {#INST} DB {#DBNAME}: Database Status</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>mssql.named.dbstatus[{#INST},{#DBNAME}]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>0</trends>
+              <status>0</status>
+              <value_type>4</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL DATABASE</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Access Methods\Page Splits/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Access Methods\Page Splits/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL ACCESS METHODS</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Bytes Received from Replica/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Availability Replica(_Total)\Bytes Received from Replica/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Bytes Sent to Replica/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Availability Replica(_Total)\Bytes Sent to Replica/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Bytes Sent to Transport/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Availability Replica(_Total)\Bytes Sent to Transport/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Flow Control/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Availability Replica(_Total)\Flow Control/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Flow Control Time (ms/sec)</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Availability Replica(_Total)\Flow Control Time (ms/sec)&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Receives from Replica/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Availability Replica(_Total)\Receives from Replica/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Resent Messages/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Availability Replica(_Total)\Resent Messages/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Sends to Replica/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Availability Replica(_Total)\Sends to Replica/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Sends to Transport/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Availability Replica(_Total)\Sends to Transport/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Buffer Manager\Page life expectancy</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Buffer Manager\Page life expectancy&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL MEMORY</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Buffer Manager\Page reads/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Buffer Manager\Page reads/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL MEMORY</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Buffer Manager\Page writes/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Buffer Manager\Page writes/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL MEMORY</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Database Flow Control Delay</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Database Flow Control Delay&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Database Flow Controls/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Database Flow Controls/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: File Bytes Received/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\File Bytes Received/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Group Commits/Sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Group Commits/Sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Group Commit Time</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Group Commit Time&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Log Bytes Compressed/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Log Bytes Compressed/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Log Bytes Decompressed/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Log Bytes Decompressed/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Log Bytes Received/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Log Bytes Received/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Log Compression Cache hits/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Log Compression Cache hits/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Log Compression Cache misses/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Log Compression Cache misses/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Log Compressions/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Log Compressions/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Log Decompressions/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Log Decompressions/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Log remaining for undo</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Log remaining for undo&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Log Send Queue</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Log Send Queue&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Mirrored Write Transactions/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Mirrored Write Transactions/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Recovery Queue</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Recovery Queue&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Redo blocked/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Redo blocked/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Redo Bytes Remaining</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Redo Bytes Remaining&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Redone Bytes/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Redone Bytes/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes />
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Redones/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Redones/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Total Log requiring undo</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Total Log requiring undo&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Transaction Delay</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Database Replica(_Total)\Transaction Delay&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL REPLICA</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}: Databases(_Total)\Percent Log Used</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Databases(_Total)\Percent Log Used&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL DATABASE</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST} DB {#DBNAME}: Active Transactions</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Active Transactions&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description>Number of active transactions for the database.</description>
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL DATABASE</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST} DB {#DBNAME}: Data File Size</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Data File(s) Size (KB)&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units>B</units>
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description>Cumulative size (in kilobytes) of all the data files in the database including any automatic growth. Monitoring this counter is useful, for example, for determining the correct size of tempdb.</description>
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing>
+                <step>
+                  <type>1</type>
+                  <params>1024</params>
+                </step>
+              </preprocessing>
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL DATABASE</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Bytes Flushed/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Log Bytes Flushed/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units>B</units>
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description>Total number of log bytes flushed per second. Useful for determining trends and utilization of the transaction log.</description>
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL DATABASE</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST} DB {#DBNAME}: Log File Size</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Log File(s) Size (KB)&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units>B</units>
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description>Cumulative size (in kilobytes) of all the transaction log files in the database.</description>
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing>
+                <step>
+                  <type>1</type>
+                  <params>1024</params>
+                </step>
+              </preprocessing>
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL DATABASE</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST} DB {#DBNAME}: Log File Used Size</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Log File(s) Used Size (KB)&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units>B</units>
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description>The cumulative used size of all the log files in the database.</description>
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing>
+                <step>
+                  <type>1</type>
+                  <params>1024</params>
+                </step>
+              </preprocessing>
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL DATABASE</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Flushes/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Log Flushes/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description>Number of log flushes per second.</description>
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL DATABASE</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Flush Waits/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Log Flush Waits/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description>Number of commits per second waiting for the log flush.</description>
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL DATABASE</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Flush Wait Time</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Log Flush Wait Time&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units>ms</units>
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description>Total wait time (in milliseconds) to flush the log. On an AlwaysOn secondary database, this value indicates the wait time for log records to be hardened to disk.</description>
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL DATABASE</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Growths</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Log Growths&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description>Total number of times the transaction log for the database has been expanded.</description>
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL DATABASE</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Shrinks</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Log Shrinks&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description>Total number of times the transaction log for the database has been shrunk.</description>
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL DATABASE</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST} DB {#DBNAME}: Log Truncations</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Log Truncations&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>1</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description>The number of times the transaction log has been shrunk.</description>
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL DATABASE</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST} DB {#DBNAME}: Percent Log Used</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Percent Log Used&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units>%</units>
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description>Percentage of space in the log that is in use.</description>
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL DATABASE</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST} DB {#DBNAME}: Transactions per second</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Databases({#DBNAME})\Transactions/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL DATABASE</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:General Statistics\Processes Blocked</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:General Statistics\Processes Blocked&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL STATS</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:General Statistics\User Connections</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:General Statistics\User Connections&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL STATS</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:Locks(_Total)\Lock Timeouts/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Locks(_Total)\Lock Timeouts/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL LOCKS</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:Locks(_Total)\Number of Deadlocks/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Locks(_Total)\Number of Deadlocks/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL LOCKS</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:Memory Manager\Memory Grants Pending</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Memory Manager\Memory Grants Pending&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL MEMORY</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:Memory Manager\Target Server Memory (KB)</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Memory Manager\Target Server Memory (KB)&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units>KB</units>
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL MEMORY</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:Memory Manager\Total Server Memory (KB)</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Memory Manager\Total Server Memory (KB)&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units>KB</units>
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL MEMORY</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:SQL Statistics\Batch Requests/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:SQL Statistics\Batch Requests/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL STATS</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:SQL Statistics\SQL Compilations/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:SQL Statistics\SQL Compilations/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL STATS</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:SQL Statistics\SQL Re-Compilations/sec</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:SQL Statistics\SQL Re-Compilations/sec&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units />
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL STATS</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:Memory grant queue waits/Average wait time (ms)</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Average wait time (ms))\Memory grant queue waits&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units>ms</units>
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL WAITS</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:Network IO waits/Average wait time (ms)</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Average wait time (ms))\Network IO waits&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units>ms</units>
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL WAITS</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:Page IO latch waits/Average wait time (ms)</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Average wait time (ms))\Page IO latch waits&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units>ms</units>
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL WAITS</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:Memory grant queue waits/Cumulative wait time (ms) per second</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Cumulative wait time (ms) per second)\Memory grant queue waits&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units>ms</units>
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL WAITS</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:Network IO waits/Cumulative wait time (ms) per second</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Cumulative wait time (ms) per second)\Network IO waits&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units>ms</units>
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL WAITS</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:Page IO latch waits/Cumulative wait time (ms) per second</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Cumulative wait time (ms) per second)\Page IO latch waits&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units>ms</units>
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL WAITS</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:Memory grant queue waits/Waits in progress</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Waits in progress)\Memory grant queue waits&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units>ms</units>
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL WAITS</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:Network IO waits/Waits in progress</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Waits in progress)\Network IO waits&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units>ms</units>
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL WAITS</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:Page IO latch waits/Waits in progress</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Waits in progress)\Page IO latch waits&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units>ms</units>
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL WAITS</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:Memory grant queue waits/Waits started per second</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Waits started per second)\Memory grant queue waits&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units>ms</units>
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL WAITS</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:Network IO waits/Waits started per second</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Waits started per second)\Network IO waits&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units>ms</units>
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL WAITS</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+            <item_prototype>
+              <name>SQL Server Instance {#INST}:Page IO latch waits/Waits started per second</name>
+              <type>0</type>
+              <snmp_community />
+              <snmp_oid />
+              <key>perf_counter[&quot;\MSSQL${#INST}:Wait Statistics(Waits started per second)\Page IO latch waits&quot;]</key>
+              <delay>1m</delay>
+              <history>90d</history>
+              <trends>365d</trends>
+              <status>0</status>
+              <value_type>0</value_type>
+              <allowed_hosts />
+              <units>ms</units>
+              <snmpv3_contextname />
+              <snmpv3_securityname />
+              <snmpv3_securitylevel>0</snmpv3_securitylevel>
+              <snmpv3_authprotocol>0</snmpv3_authprotocol>
+              <snmpv3_authpassphrase />
+              <snmpv3_privprotocol>0</snmpv3_privprotocol>
+              <snmpv3_privpassphrase />
+              <params />
+              <ipmi_sensor />
+              <authtype>0</authtype>
+              <username />
+              <password />
+              <publickey />
+              <privatekey />
+              <port />
+              <description />
+              <inventory_link>0</inventory_link>
+              <applications />
+              <valuemap />
+              <logtimefmt />
+              <preprocessing />
+              <jmx_endpoint />
+              <timeout>3s</timeout>
+              <url />
+              <query_fields />
+              <posts />
+              <status_codes>200</status_codes>
+              <follow_redirects>1</follow_redirects>
+              <post_type>0</post_type>
+              <http_proxy />
+              <headers />
+              <retrieve_mode>0</retrieve_mode>
+              <request_method>0</request_method>
+              <output_format>0</output_format>
+              <allow_traps>0</allow_traps>
+              <ssl_cert_file />
+              <ssl_key_file />
+              <ssl_key_password />
+              <verify_peer>0</verify_peer>
+              <verify_host>0</verify_host>
+              <application_prototypes>
+                <application_prototype>
+                  <name>MSSQL WAITS</name>
+                </application_prototype>
+              </application_prototypes>
+              <master_item />
+            </item_prototype>
+          </item_prototypes>
+          <trigger_prototypes />
+          <graph_prototypes />
+          <host_prototypes />
+          <jmx_endpoint />
+          <timeout>3s</timeout>
+          <url />
+          <query_fields />
+          <posts />
+          <status_codes>200</status_codes>
+          <follow_redirects>1</follow_redirects>
+          <post_type>0</post_type>
+          <http_proxy />
+          <headers />
+          <retrieve_mode>0</retrieve_mode>
+          <request_method>0</request_method>
+          <allow_traps>0</allow_traps>
+          <ssl_cert_file />
+          <ssl_key_file />
+          <ssl_key_password />
+          <verify_peer>0</verify_peer>
+          <verify_host>0</verify_host>
+        </discovery_rule>
+      </discovery_rules>
+      <httptests />
+      <macros />
+      <templates />
+      <screens />
+    </template>
+  </templates>
 </zabbix_export>

--- a/files/conf.d/userparameter_mssql.conf
+++ b/files/conf.d/userparameter_mssql.conf
@@ -1,5 +1,6 @@
 UserParameter=mssql.named.db.discovery,powershell -NoProfile -ExecutionPolicy Bypass -File "C:\Zabbix_Agent\scripts\mssql_named_disc.ps1"
 UserParameter=mssql.default.db.discovery,powershell -NoProfile -ExecutionPolicy Bypass -File "C:\Zabbix_Agent\scripts\mssql_default_disc.ps1"
-UserParameter=mssql.errorlog,powershell -NoProfile -ExecutionPolicy Bypass -File "C:\Zabbix_Agent\scripts\logreader.ps1"
+UserParameter=mssql.errorlog,powershell -NoProfile -ExecutionPolicy Bypass -File "C:\Zabbix_Agent\scripts\mssql_errorlog_discovery.ps1"
 UserParameter=mssql.default.dbstatus[*],powershell -NoProfile -ExecutionPolicy Bypass C:\Zabbix_Agent\scripts\database_status_disc.ps1 -instName "$1" -dbName "$2"
 UserParameter=mssql.named.dbstatus[*],powershell -NoProfile -ExecutionPolicy Bypass C:\Zabbix_Agent\scripts\database_status_disc.ps1 -instName "$1" -dbName "$2"
+UserParameter=mssql.errorlog.errors[*],powershell -NoProfile -ExecutionPolicy Bypass C:\Zabbix_Agent\scripts\mssql_errorlog_parser.ps1 -instName "$1" -errorLogPath '"$2"'

--- a/files/conf.d/userparameter_mssql.conf
+++ b/files/conf.d/userparameter_mssql.conf
@@ -1,3 +1,5 @@
-UserParameter=mssql.db.discovery,powershell -NoProfile -ExecutionPolicy Bypass -File "C:\Program Files\Zabbix Agent\scripts\mssql_basename_new.ps1"
-UserParameter=mssql.errorlog,powershell -NoProfile -ExecutionPolicy Bypass -File "C:\Program Files\Zabbix Agent\scripts\logreader.ps1"
-UserParameter=mssql.dbstatus[*],powershell -NoProfile -ExecutionPolicy Bypass "C:\Program Files\Zabbix Agent\scripts\database_status_disc.ps1" -instName "$1" -dbName "$2"
+UserParameter=mssql.named.db.discovery,powershell -NoProfile -ExecutionPolicy Bypass -File "C:\Zabbix_Agent\scripts\mssql_named_disc.ps1"
+UserParameter=mssql.default.db.discovery,powershell -NoProfile -ExecutionPolicy Bypass -File "C:\Zabbix_Agent\scripts\mssql_default_disc.ps1"
+UserParameter=mssql.errorlog,powershell -NoProfile -ExecutionPolicy Bypass -File "C:\Zabbix_Agent\scripts\logreader.ps1"
+UserParameter=mssql.default.dbstatus[*],powershell -NoProfile -ExecutionPolicy Bypass C:\Zabbix_Agent\scripts\database_status_disc.ps1 -instName "$1" -dbName "$2"
+UserParameter=mssql.named.dbstatus[*],powershell -NoProfile -ExecutionPolicy Bypass C:\Zabbix_Agent\scripts\database_status_disc.ps1 -instName "$1" -dbName "$2"

--- a/files/conf.d/userparameter_mssql.conf
+++ b/files/conf.d/userparameter_mssql.conf
@@ -1,3 +1,3 @@
 UserParameter=mssql.db.discovery,powershell -NoProfile -ExecutionPolicy Bypass -File "C:\Program Files\Zabbix Agent\scripts\mssql_basename_new.ps1"
-UserParameter=mssql.discovery2,powershell -NoProfile -ExecutionPolicy Bypass -File "C:\Program Files\Zabbix Agent\scripts\mssql_basename_new.ps1"
 UserParameter=mssql.errorlog,powershell -NoProfile -ExecutionPolicy Bypass -File "C:\Program Files\Zabbix Agent\scripts\logreader.ps1"
+UserParameter=mssql.dbstatus[*],powershell -NoProfile -ExecutionPolicy Bypass "C:\Program Files\Zabbix Agent\scripts\database_status_disc.ps1" -instName "$1" -dbName "$2"

--- a/files/scripts/database_status_disc.ps1
+++ b/files/scripts/database_status_disc.ps1
@@ -22,7 +22,7 @@ function convertto-encoding ([string]$from, [string]$to){
 $SQLServer = $(hostname.exe)
 
 # Now, we find all services that start with MSSQL$ and loop through them
-Get-Service | Where-Object {($_.Name -like "MSSQL`$$instName") -or ($_.Name -eq 'MSSQLSERVER' -and $instName -eq 'MSSQLSERVER')}| ForEach-Object{
+Get-Service | Where-Object {($_.Name -like "MSSQL`$$instName") -or ($_.Name -eq 'MSSQLSERVER' -and $instName -eq 'MSSQLSERVER') -and $_.Status -eq 'Running'}| ForEach-Object{
 
     if ($_.Name -like 'MSSQL$*') {
         # For named instances, we want to connect to ServerName\InstanceName

--- a/files/scripts/database_status_disc.ps1
+++ b/files/scripts/database_status_disc.ps1
@@ -20,19 +20,19 @@ function convertto-encoding ([string]$from, [string]$to){
 
 # First, grab our hostname
 $SQLServer = $(hostname.exe)
-# Now, we find all services that start with MSSQL$ and loop through them
-Get-Service | Where-Object {$_.Name -like 'MSSQL$*'}| ForEach-Object{
-    # Take our service name string and massage it a bit,
-    # we end up with SERVERNAME\INSTANCE
-    $dirtyInstanceName = "$($_.Name)"
-    $cleanInstanceSplit = $dirtyInstanceName -split "\$"
-    $cleanInstance = $cleanInstanceSplit[1]
-    $fullInstance = $SQLServer + "\$cleanInstance"
 
-    ## Check to see if this instance matches the instance name that was
-    ## passed on the command line. If not, skip it
-    if ($fullInstance -notlike "*$instName*"){
-        return
+# Now, we find all services that start with MSSQL$ and loop through them
+Get-Service | Where-Object {($_.Name -like "MSSQL`$$instName") -or ($_.Name -eq 'MSSQLSERVER' -and $instName -eq 'MSSQLSERVER')}| ForEach-Object{
+
+    if ($_.Name -like 'MSSQL$*') {
+        # For named instances, we want to connect to ServerName\InstanceName
+        $dirtyInstanceName = "$($_.Name)"
+        $cleanInstanceSplit = $dirtyInstanceName -split "\$"
+        $cleanInstance = $cleanInstanceSplit[1]
+        $fullInstance = $SQLServer + "\$cleanInstance"
+    } else {
+        # For default instance, we want to connect only to ServerName
+        $fullInstance = $SQLServer
     }
 
     # Create a connection string to connect to this instance, on this server.

--- a/files/scripts/mssql_default_disc.ps1
+++ b/files/scripts/mssql_default_disc.ps1
@@ -80,7 +80,13 @@ write-host "{"
 write-host " `"data`":[`n"
 foreach ($name in $basename)
 {
-    if ($idx -lt $basename.Count)
+    if ($psVersionTable.CLRVersion -like '2.*') { #this is dumb, but if you can't rely on PS/.NET version being current on monitored hosts, it's necessary
+        $itemCount = $basename.Count
+    } else {
+        $itemCount = $basename.Rows.Count
+    }
+
+    if ($idx -lt $itemCount)
         {
             $line= "{ `"{#INST}`" : `"" + $name.inst + "`", "  + "`"{#DBNAME}`" : `"" + $name.name + "`" }," | convertto-encoding "cp866" "utf-8"
             write-host $line
@@ -88,7 +94,7 @@ foreach ($name in $basename)
     # If this is the last row, we print a slightly different string - one without the trailing comma
     # Although I don't think the trailing comma would technically break JSON, this is the right way
     # to do it.
-    elseif ($idx -ge $basename.Count)
+    elseif ($idx -ge $itemCount)
         {
             $line= "{ `"{#INST}`" : `"" + $name.inst + "`", "  + "`"{#DBNAME}`" : `"" + $name.name + "`" }" | convertto-encoding "cp866" "utf-8"
             write-host $line

--- a/files/scripts/mssql_errorlog_discovery.ps1
+++ b/files/scripts/mssql_errorlog_discovery.ps1
@@ -78,7 +78,7 @@ write-host "{"
 write-host " `"data`":[`n"
 foreach ($name in $basename)
 {
-    if ($idx -lt $basename.Rows.Count)
+    if ($idx -lt $basename.Count)
         {
             # Escape those backslashes
             $cName = $name.fileLoc -replace "\\", "\\"
@@ -86,7 +86,7 @@ foreach ($name in $basename)
             write-host $line
         }
     # If this is the last row, we print a slightly different string - one without the trailing comma
-    elseif ($idx -ge $basename.Rows.Count)
+    elseif ($idx -ge $basename.Count)
         {
             $cName = $name.fileLoc -replace "\\", "\\"
             $line= "{ `"{#INST}`" : `"" + $name.inst + "`", "  + "`"{#ERRORLOG}`" : `"" + $cName + "`" }" | convertto-encoding "cp866" "utf-8"

--- a/files/scripts/mssql_errorlog_parser.ps1
+++ b/files/scripts/mssql_errorlog_parser.ps1
@@ -1,0 +1,68 @@
+﻿Param(
+    [string]$instName # {#INST} macro from Zabbix
+  , [string]$errorLogPath # {#ERRORLOG} macro from Zabbix
+)
+
+$ErrorActionPreference = "Stop"
+
+#$bookmarkFileName = ('C:\Zabbix_Agent\zabbix_errorlog_bookmark_MSSQL${0}' -f $instName)
+$bookmarkFileName = ('{0}\zabbix_errorlog_bookmark_MSSQL${1}' -f $env:USERPROFILE, $instName)
+
+$errorLogPath = $errorLogPath.Replace("'","")
+
+#Write-Output ('errorLogPath = {0}' -f $errorLogPath)
+#Write-Output ('bookmarkFileName = {0}' -f $bookmarkFileName)
+
+
+# Get the time of the last check from the bookmark file. This way we can return only errors logged since the last time Zabbix checked.
+try {
+    [datetime]$lastCheckTime = Get-Content $bookmarkFileName
+} catch {
+    # default to checking last minute (e.g. if first time this check has been run, or if someone deleted the bookmark file)
+    [datetime]$lastCheckTime = (Get-Date).AddMinutes(-1)
+}
+
+# Now update the bookmark with the current time. (Do it now to minimize window for missing logged errors between checks.)
+Write-Output (Get-Date).ToString('yyyy-MM-dd HH:mm:ss') | Out-File $bookmarkFileName
+
+$recent_errors = @()
+
+try {
+    # use .NET streamreader to keep it lightweight with large errorlog files
+    $logFile = [System.IO.File]::Open(('{0}' -f $errorLogPath), 'Open', 'Read', 'ReadWrite') # allows reading errorlog while SQL Server has it open for writes
+    $logReader = New-Object System.IO.StreamReader($logFile)
+    $errorFound = $false
+    while (-not $logReader.EndOfStream) {
+        # SQL Server logs 2 lines in errorlog for an error. The first line contains the error number, and severity & state codes.
+        # The second line contains the actual message text that is necessary to understand the error.
+        # Thus, we need to get two lines of log for each error.
+
+        $line = $logReader.ReadLine()
+
+        try {
+            $lineTimestamp = [datetime]($line.Substring(0,22))
+        } catch [System.Management.Automation.RuntimeException] { # log line doesn't begin with timestamp (e.g. log file header)
+            $lineTimestamp = $null
+        }
+
+        if ($lineTimestamp -gt $lastCheckTime) {
+            if ($true) {
+                if ($errorFound) {
+                    $recent_errors += $line
+                    $errorFound = $false # reset to looking for first line of an error
+                }
+                elseif ([regex]::IsMatch($line, 'Error:') -and -not $errorFound) {
+                    $recent_errors += $line
+                    $errorFound = $true
+                }
+            }
+        }
+    }
+} catch {
+    throw
+} finally {
+    $logReader.Close()
+    $logFile.Close()
+}
+
+return $recent_errors

--- a/files/scripts/mssql_named_disc.ps1
+++ b/files/scripts/mssql_named_disc.ps1
@@ -78,7 +78,12 @@ write-host "{"
 write-host " `"data`":[`n"
 foreach ($name in $basename)
 {
-    if ($idx -lt $basename.Count)
+    if ($psVersionTable.CLRVersion -like '2.*') { #this is dumb, but if you can't rely on PS/.NET version being current on monitored hosts, it's necessary
+        $itemCount = $basename.Count
+    } else {
+        $itemCount = $basename.Rows.Count
+    }
+    if ($idx -lt $itemCount)
         {
             $line= "{ `"{#INST}`" : `"" + $name.inst + "`", "  + "`"{#DBNAME}`" : `"" + $name.name + "`" }," | convertto-encoding "cp866" "utf-8"
             write-host $line
@@ -86,7 +91,7 @@ foreach ($name in $basename)
     # If this is the last row, we print a slightly different string - one without the trailing comma
     # Although I don't think the trailing comma would technically break JSON, this is the right way
     # to do it.
-    elseif ($idx -ge $basename.Count)
+    elseif ($idx -ge $itemCount)
         {
             $line= "{ `"{#INST}`" : `"" + $name.inst + "`", "  + "`"{#DBNAME}`" : `"" + $name.name + "`" }" | convertto-encoding "cp866" "utf-8"
             write-host $line

--- a/files/scripts/mssql_named_disc.ps1
+++ b/files/scripts/mssql_named_disc.ps1
@@ -1,6 +1,6 @@
-﻿## This script exists to grab all MSSQL instances running on
-## a server, loop through them, and find the location of 
-## their error log file.
+## This script exists to grab all MSSQL instances running on
+## a server, loop through them, and find the databases within
+## them, returning a JSON string of the results.
 
 # This function converts from one encoding to another.
 function convertto-encoding ([string]$from, [string]$to){
@@ -15,11 +15,10 @@ function convertto-encoding ([string]$from, [string]$to){
     }
 }
 
-
 # First, grab our hostname
 $SQLServer = $(hostname.exe)
 # Now, we find all services that start with MSSQL$ and loop through them
-Get-Service | Where-Object {($_.Name -like 'MSSQL$*' -or $_.Name -eq 'MSSQLSERVER') -and $_.Status -eq 'Running'}| ForEach-Object{
+Get-Service | Where-Object {$_.Name -like 'MSSQL$*' -and $_.Status -eq 'Running'}| ForEach-Object{
     # Take our service name string and massage it a bit,
     # we end up with SERVERNAME\INSTANCE
     $dirtyInstanceName = "$($_.Name)"
@@ -30,7 +29,7 @@ Get-Service | Where-Object {($_.Name -like 'MSSQL$*' -or $_.Name -eq 'MSSQLSERVE
     # Create a connection string to connect to this instance, on this server.
     # Turn on Integrated Security so we authenticate as the account running
     # the script without a prompt.
-    $connectionString = "Server = $fullInstance; Integrated Security = True;"
+    $connectionString = "Server = $fullInstance; Integrated Security = True; Connection Timeout = 2"
 
     # Create a new connection object with that connection string
     $connection = New-Object System.Data.SqlClient.SqlConnection
@@ -51,7 +50,7 @@ Get-Service | Where-Object {($_.Name -like 'MSSQL$*' -or $_.Name -eq 'MSSQLSERVE
                 # Create a MSSQL request
                 $SqlCmd = New-Object System.Data.SqlClient.SqlCommand
                 # Select all the database names within this instance  
-                $SqlCmd.CommandText = "SELECT @@servicename as inst, SERVERPROPERTY('ErrorLogFileName') AS 'fileLoc'"
+                $SqlCmd.CommandText = "SELECT @@servicename as inst, name FROM  sysdatabases"
                 $SqlCmd.Connection = $Connection
                 $SqlAdapter = New-Object System.Data.SqlClient.SqlDataAdapter
                 $SqlAdapter.SelectCommand = $SqlCmd
@@ -71,25 +70,25 @@ Get-Service | Where-Object {($_.Name -like 'MSSQL$*' -or $_.Name -eq 'MSSQLSERVE
         $basename = $basename + $DataSet.Tables[0]
     }
 }
-# So now $basename is full of our instance and logfile rows
+
+# So now $basename is full of our instance and database name rows
 # We loop through them and print the results as a JSON string
 $idx = 1
 write-host "{"
 write-host " `"data`":[`n"
 foreach ($name in $basename)
 {
-    if ($idx -lt $basename.Rows.Count)
+    if ($idx -lt $basename.Count)
         {
-            # Escape those backslashes
-            $cName = $name.fileLoc -replace "\\", "\\"
-            $line= "{ `"{#INST}`" : `"" + $name.inst + "`", "  + "`"{#ERRORLOG}`" : `"" + $cName + "`" }," | convertto-encoding "cp866" "utf-8"
+            $line= "{ `"{#INST}`" : `"" + $name.inst + "`", "  + "`"{#DBNAME}`" : `"" + $name.name + "`" }," | convertto-encoding "cp866" "utf-8"
             write-host $line
         }
     # If this is the last row, we print a slightly different string - one without the trailing comma
-    elseif ($idx -ge $basename.Rows.Count)
+    # Although I don't think the trailing comma would technically break JSON, this is the right way
+    # to do it.
+    elseif ($idx -ge $basename.Count)
         {
-            $cName = $name.fileLoc -replace "\\", "\\"
-            $line= "{ `"{#INST}`" : `"" + $name.inst + "`", "  + "`"{#ERRORLOG}`" : `"" + $cName + "`" }" | convertto-encoding "cp866" "utf-8"
+            $line= "{ `"{#INST}`" : `"" + $name.inst + "`", "  + "`"{#DBNAME}`" : `"" + $name.name + "`" }" | convertto-encoding "cp866" "utf-8"
             write-host $line
         }
     $idx++;


### PR DESCRIPTION
I made a few enhancements & fixes based on my environment's needs:

- Added perfmon counter Processes Blocked.
- Fixed some issues with item prototypes causing items not to work.
    - Commas in item prototype names interfered with pulling those items' data into dashboard widgets.
    - Unsigned integer value type was causing many perfmon counters not to retrieve data. Changed to float for all numeric items.
- Also discover default instance of SQL Server. Previously, only named instances could be discovered.
    - The fastest way I was able to achieve this was to create a second discovery rule, but that required duplicating the Powershell to discover MSSQL as well as duplicating all of the item prototypes for database discovery. In the future this should be refactored to eliminate duplication, if possible.
- Implemented log parsing in Powershell for the SQL Server errorlog, to facilitate seeing the actual error message text in Zabbix in addition to the error number/severity/state.